### PR TITLE
[BLUEPRINT][API] #6 — Zerado interface contracts: provider, metadata, price, repository, error, CLI and Phase 4 seams

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,54 @@
+name: go
+
+# Mirrors the guardrails workflow's trigger, and deliberately so: Release
+# Discipline puts the gating CI on main only, so this runs when a release line
+# is merged into main rather than on every branch. It is not path-filtered —
+# a change to go.mod or to a workflow can break the build without touching a
+# .go file.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: go-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: build, vet and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          check-latest: true
+
+      - name: Everything is gofmt-clean
+        run: |
+          unformatted="$(gofmt -l ./internal)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt would change these files:"
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "OK — gofmt-clean."
+
+      - name: Build
+        run: go build ./internal/...
+
+      - name: Vet
+        run: go vet ./internal/...
+
+      # -race because the sync stream's progress snapshot is read from the
+      # render goroutine while the provider's goroutine writes it. That
+      # contract is unenforceable without this flag.
+      - name: Test
+        run: go test -race ./internal/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,10 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Read from go.mod rather than repeated here. A version in two places is
+      # a version that drifts, and the pin exists precisely so that everything
+      # — the review vehicle, a contributor's build, this job — resolves the
+      # same toolchain.
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
-          check-latest: true
+          go-version-file: go.mod
 
       - name: Everything is gofmt-clean
         run: |

--- a/docs/api/00-index.md
+++ b/docs/api/00-index.md
@@ -1,0 +1,175 @@
+---
+title: Zerado — interface contracts
+discipline: API
+doc-no: ZRD-API-00
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: implementation-plan
+ticket: "#6"
+---
+
+# The contracts
+
+Nine seams, their exact Go shape, and the reasoning that chose each one.
+
+The spine ([`../blueprint/06-data-seams.md`](../blueprint/06-data-seams.md)) decided **that** these
+seams exist and what each is responsible for. This deliverable decides their **signatures** — the
+job [`../blueprint/13-handoffs.md`](../blueprint/13-handoffs.md) §1 assigns to it: final
+signatures, error contracts and sentinel errors, context and cancellation semantics, versioning and
+stability guarantees, and package layout.
+
+**No implementation is written.** What ships is contracts, doc comments, three `Null`
+implementations the ADR itself designates as first-class states, one hand-entry reference provider,
+five test fakes, and the tests that make the contracts checkable rather than assertable.
+
+---
+
+## 1 · Where everything is
+
+| Package | Seam | Ticket item |
+|---|---|---|
+| `internal/provider` | Store provider — `Provider` · `Syncer` · `Enterer` | 1 |
+| `internal/metadata` | Enrichment — covers, *sinopse*, genres, release data | 2 |
+| `internal/pricing` | Price — current, all-time low, wait-or-buy | 3 |
+| `internal/store` | The repository seam over `fft-database`'s schema | 4 |
+| `internal/fault` | The error taxonomy | 5 |
+| `internal/aged` | The staleness contract | 6 |
+| `internal/cli` | The CLI verb surface as a versioned API | 7 |
+| `internal/devicesync` | The Phase 4 boundary, sketched | 8 |
+| `internal/library` | Domain types — and where item 9 is answered by *not* generalising | 9 |
+| `internal/vault` · `internal/images` · `internal/audio` | Credentials · terminal images · sound | — |
+| `internal/status` · `internal/i18n` | The four states · the catalogue key | — |
+| `internal/arch` | No code. The tests that keep the import graph honest | — |
+
+The reasoning for each signature is in its doc comment, beside the signature, because a decision
+recorded somewhere else is a decision the next person changes without reading. This document holds
+what does not belong to a single declaration.
+
+---
+
+## 2 · The gate question, answered by demonstration
+
+> **Can a second store, a second metadata source, and a second media type each be added without
+> changing a signature above the seam?** *Show it, do not assert it.*
+
+### 2.1 · A second store
+
+`internal/provider` carries **two implementations already**, and they are as different as the
+product will ever have to accommodate:
+
+| | `providertest.Fake` | `providertest.Manual` |
+|---|---|---|
+| What it is | a network store | a person typing |
+| Implements | `Provider` + `Syncer` | `Provider` + `Enterer` |
+| Credentials | two fields, one secret | **none** |
+| Playtime | reported | **unknowable** |
+| Item source | a stream | a form |
+| Provider reference | the store's own id | **a UUID Zerado mints** |
+
+Both produce the same `provider.Item`, both travel the same `Store.UpsertBatch` path, and the four
+states derive correctly for both from `Capabilities` with no branch on identity anywhere.
+
+`TestManualIsNotASyncer` asserts the negative the compiler cannot: hand entry does **not** implement
+`Syncer`. `TestCapabilitiesAgreeWithTheInterfaces` asserts the positive.
+
+**Adding GOG** is: implement the interfaces, declare the credential fields, register. Screens change
+by zero, because `Z-02` renders `Capabilities().Credentials` and `Z-04` reads `Capabilities`.
+
+### 2.2 · A second metadata source
+
+`internal/metadata` also carries two — `metadata.Null` and `metadatatest.Fake` — and
+`TestTheSeamNamesNoProvider` runs the same call against both through the interface.
+
+The stronger evidence is what is **absent**: the word IGDB appears in one package comment,
+explaining the hedge, and **nowhere in any signature, type, field or constant**. The fake is keyed on
+**title and platform**, not on a store identifier — which is the shape a source that has never heard
+of Steam would have, and therefore the shape a cartridge needs. A fake keyed on an appid would have
+agreed with a Steam-shaped seam and proved nothing.
+
+`Attribution()` is a method, so swapping the source swaps the credit and a licence change is a data
+change rather than a redesign.
+
+### 2.3 · A second media type
+
+**The ratified answer is that there must not be a generic seam, and the demonstration is that the
+cost of adding one later is two columns.**
+
+The ticket asks for "the seams that must be generic so books plug in". ADR-0001 **D5** pruned that,
+and [`../blueprint/06-data-seams.md`](../blueprint/06-data-seams.md) §7 lists a media-type
+abstraction as explicitly **not a seam**: *"an interface parameterised on a type that has one value
+is machinery without a purpose."*
+
+So `library.Game` has no type parameter and no `MediaType` field. The door is held open by the
+schema — the entity is `item`, carrying an `item_type` constrained to `'game'` — which is one
+`CHECK` constraint away from a second type and requires **no interface change at all**, because
+nothing above the store reads a media type today and nothing would need to.
+
+Recorded as a divergence from the ticket's wording, with the ratified authority named, in
+[`06-divergences.md`](./06-divergences.md) §1. **Ratified canon wins over ticket prose; the
+disagreement is surfaced rather than silently resolved.**
+
+---
+
+## 3 · Every seam is fakeable with no network
+
+The ticket makes this a correctness test of the shape: *if it cannot be tested offline, the shape is
+wrong.*
+
+| Seam | Offline double | Reaches |
+|---|---|---|
+| Store provider | `providertest.Fake` · `providertest.Manual` | nothing |
+| Metadata | `metadata.Null` · `metadatatest.Fake` | nothing |
+| Price | `pricingtest.Fake` | nothing |
+| Repository | `storetest.Fake` (in-memory) | nothing |
+| Credentials | `vaulttest.Fake` | nothing |
+| Images | `images.Null` | nothing |
+| Audio | `audio.Null` · `audiotest.Recorder` | nothing |
+| Error classifier | `fault.Classify` is a **pure function** over a `Transport` verdict | nothing |
+
+The whole test suite runs with the machine in a Faraday cage and with an **empty `go.sum`** — there
+is no third-party dependency to download, which `TestTheModuleHasNoThirdPartyDependencies` records
+as a property of this stage rather than a permanent rule.
+
+**`internal/arch` makes it structural rather than habitual.** `TestOnlyProvidersMayReachTheNetwork`
+parses every non-test file in the module and fails if any package outside `internal/provider`
+imports `net`, `net/http`, `net/url`, `crypto/tls` or `net/rpc`. That is
+[`../blueprint/07-offline-contract.md`](../blueprint/07-offline-contract.md) §7.3's proposed
+grep-level review rule, executable — because a rule nobody can check is a convention, and
+conventions lose to deadlines. The guard was verified by temporarily adding a violating import and
+watching it fail, then reverting.
+
+---
+
+## 4 · The documents
+
+| | |
+|---|---|
+| [`01-seams.md`](./01-seams.md) | The nine seams, what each decided and why |
+| [`02-error-taxonomy.md`](./02-error-taxonomy.md) | Thirteen kinds × treatment × copy × exit code |
+| [`03-cli-surface.md`](./03-cli-surface.md) | Verbs, flags, exit codes, output, stability policy |
+| [`04-concurrency-and-offline.md`](./04-concurrency-and-offline.md) | Context, cancellation, the streaming shape, the age rule |
+| [`05-phase4-sketch.md`](./05-phase4-sketch.md) | What crosses, and what Phase 1 must not make impossible |
+| [`06-divergences.md`](./06-divergences.md) | Every departure from the spine's spelling, with its reason |
+| [`07-open-questions.md`](./07-open-questions.md) | What this ticket did not decide, and who owns it |
+
+---
+
+## 5 · The assumption this deliverable makes about `fft-database`
+
+Ticket #5 designs the physical schema **in parallel with this one**. Rather than block, the
+assumption is stated so it can be checked in one place:
+
+> **The repository interface is written against the *conceptual* model in
+> [`../blueprint/09-erd.md`](../blueprint/09-erd.md), and assumes only its load-bearing claims** —
+> `status_manual` nullable, `last_played_at NULL` meaning *not reported*, `absent_since` nullable,
+> the item identity indexed and **not** unique, `(provider_id, provider_ref)` unique,
+> `effective_status` derived and never stored, and `sync_run.status` ∈ `ok · partial · failed ·
+> cancelled`.
+
+Everything else — column types, index strategy, migration sequence, whether a generated column is
+worth its cost — is `fft-database`'s and **changes nothing in these signatures**, which is the point
+of the seam. The one place the two must agree on a name is the cross-device identity: the ERD calls
+it `item_uid`, [`06-data-seams.md`](../blueprint/06-data-seams.md) §6.2 calls it `game_uid`, and the
+Go type is `library.UID`. The **column name is `fft-database`'s to pick**; nothing above the store
+sees it.

--- a/docs/api/00-index.md
+++ b/docs/api/00-index.md
@@ -131,6 +131,13 @@ wrong.*
 | Audio | `audio.Null` · `audiotest.Recorder` | nothing |
 | Error classifier | `fault.Classify` is a **pure function** over a `Transport` verdict | nothing |
 
+`go.mod` pins a **full toolchain version** (`1.27.0`), not a bare language version. `go 1.24` is a
+language version and Go cannot resolve a toolchain from it, so anything that resolves the pin before
+running — the review vehicle, a reproducible build — fails *upstream of every test in this module*.
+Sprint 0 #10's acceptance criteria already required a pinned toolchain;
+`TestTheGoDirectiveIsAResolvableToolchainVersion` now makes it checkable, and the CI workflow reads
+the number from `go.mod` rather than repeating it.
+
 The whole test suite runs with the machine in a Faraday cage and with **no `go.sum` at all** —
 `go.mod` declares no `require`, so there is no third-party dependency to download and no lock file to
 write. `TestTheModuleHasNoThirdPartyDependencies` records that as a property of this stage rather

--- a/docs/api/00-index.md
+++ b/docs/api/00-index.md
@@ -81,11 +81,15 @@ by zero, because `Z-02` renders `Capabilities().Credentials` and `Z-04` reads `C
 `internal/metadata` also carries two — `metadata.Null` and `metadatatest.Fake` — and
 `TestTheSeamNamesNoProvider` runs the same call against both through the interface.
 
-The stronger evidence is what is **absent**: the word IGDB appears in one package comment,
-explaining the hedge, and **nowhere in any signature, type, field or constant**. The fake is keyed on
-**title and platform**, not on a store identifier — which is the shape a source that has never heard
-of Steam would have, and therefore the shape a cartridge needs. A fake keyed on an appid would have
-agreed with a Steam-shaped seam and proved nothing.
+The stronger evidence is what is **absent**: the word IGDB appears **only in comments** — seven
+occurrences across three files, five of them in `metadata`'s package comment explaining the hedge and
+two in `fault`, naming it as the example of a source that may never have heard of a cartridge — and
+in **no signature, type, field or constant**. *(An earlier revision of this document said "one
+package comment". The load-bearing half was right and the tally was not; corrected after the review
+at `c4c8d95` counted them.)* The fake is keyed on **title and platform**, not on a store identifier —
+which is the shape a source that has never heard of Steam would have, and therefore the shape a
+cartridge needs. A fake keyed on an appid would have agreed with a Steam-shaped seam and proved
+nothing.
 
 `Attribution()` is a method, so swapping the source swaps the credit and a licence change is a data
 change rather than a redesign.
@@ -127,9 +131,11 @@ wrong.*
 | Audio | `audio.Null` · `audiotest.Recorder` | nothing |
 | Error classifier | `fault.Classify` is a **pure function** over a `Transport` verdict | nothing |
 
-The whole test suite runs with the machine in a Faraday cage and with an **empty `go.sum`** — there
-is no third-party dependency to download, which `TestTheModuleHasNoThirdPartyDependencies` records
-as a property of this stage rather than a permanent rule.
+The whole test suite runs with the machine in a Faraday cage and with **no `go.sum` at all** —
+`go.mod` declares no `require`, so there is no third-party dependency to download and no lock file to
+write. `TestTheModuleHasNoThirdPartyDependencies` records that as a property of this stage rather
+than a permanent rule. *(An earlier revision said "an empty `go.sum`"; there is no such file. The
+substance was right and the artefact named was not.)*
 
 **`internal/arch` makes it structural rather than habitual.** `TestOnlyProvidersMayReachTheNetwork`
 parses every non-test file in the module and fails if any package outside `internal/provider`

--- a/docs/api/01-seams.md
+++ b/docs/api/01-seams.md
@@ -1,0 +1,164 @@
+---
+title: Zerado — the nine seams
+discipline: API
+doc-no: ZRD-API-01
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: implementation-plan
+ticket: "#6"
+---
+
+# The nine seams
+
+What each one decided, and the one argument that decided it. The full reasoning for every signature
+is in its doc comment; this is the map.
+
+---
+
+## 1 · The store provider — designed against the cartridge, checked against Steam
+
+The likeliest way to get this seam wrong is to design it around Steam, because Steam is the only
+provider Phase 1 builds. So it was written against **manual physical entry first** and checked
+against a store second — the reverse of the tempting order, and the reason it has **three**
+interfaces rather than one.
+
+```go
+type Provider interface {                    // every source, including a person with a keyboard
+    ID() ID
+    Display() string
+    Capabilities() Capabilities
+}
+
+type Syncer interface {                      // a source that can fetch over a network
+    Provider
+    Sync(ctx context.Context, c Credentials) (Stream, error)
+}
+
+type Enterer interface {                     // a source whose items arrive because a person typed them
+    Provider
+    Form() []EntryField
+    Compose(e Entry) (Item, error)
+}
+```
+
+Read `providertest.Manual` and note what is **absent**: no credentials, no pagination, no rate limit,
+no HTTP client, no `Sync`, no playtime. Each absence is a place a one-interface design would have
+forced physical to lie — by returning `ErrManual`, by declaring fields it does not want, or by
+reporting a zero the derivation would treat as a fact.
+
+**`Enterer` is a capability, not a provider kind.** A future GOG that syncs *and* lets a player add a
+game its API missed implements both, and `Z-08` gains a source picker rather than a special case.
+
+**Everything downstream reads `Capabilities`, never `ID`.** `provider.Check` asserts that the
+declaration and the implemented interfaces agree — because `Capabilities` deliberately duplicates two
+facts the type system already carries (screens need them before they have a reason to type-assert),
+and duplicated facts drift.
+
+**A hand-entry provider may not claim `Playtime`.** `Check` refuses the declaration, because a typed
+number would otherwise become evidence in `status.Derive`.
+
+## 2 · Metadata — a hedge whose reason changed and whose shape did not
+
+The seam was designed when IGDB's non-commercial terms sat badly against an affiliate-funded
+product. Affiliate links are dropped, so the product is cleanly non-commercial and IGDB's published
+test is answered — **as a reading of a published rationale, not a guarantee.** A direct confirmation
+is a founder action.
+
+So the hedge stays exactly as designed. Removing it because one risk receded would be the wrong
+lesson: a source that is named today can change its terms tomorrow, which is true of every source and
+is not a fact about IGDB.
+
+**The test of agnosticism:** the word IGDB appears in one package comment and in **no signature, type,
+field or constant**. The fake is keyed on **title and platform**, which is the shape a source that has
+never heard of Steam would have — and therefore the shape a cartridge needs.
+
+**`Null` is production code, not a test helper.** Having no metadata is a designed state: the detail
+view shows a designed no-metadata composition, never an error banner. That is the difference between
+a product that works without a source and one that is broken without it, and it is why
+`KindNotFound`'s treatment is `TreatmentDesignedEmpty`.
+
+## 3 · Price — the disclosure is structural
+
+`Quote` carries the current price, the all-time low, **when the low was**, the shop and a plain shop
+link. There is **no field an affiliate tag could occupy**, which is how the decision is enforced
+rather than remembered.
+
+`LowAt` is mandatory: *"it was R$ 19 once"* means something different depending on whether once was
+last month or in 2019, and only one of those should make a player wait.
+
+`Quote.Verdict` answers wait-or-buy **from one response, locally, offline** — which is what makes the
+Phase 3 watchlist a `DEGRADES` feature rather than one that stops. A verdict computed by the source
+would be a verdict Zerado could not produce when it matters.
+
+`VerdictUnknown` renders as no verdict, never as "wait". A product that guesses when it does not know
+is giving advice it has not earned.
+
+## 4 · The repository — the only thing that knows a database exists
+
+Reads take a `Query` and return domain types. Writes take domain types and return what the screen
+needs to say what happened. **No query builder, no expression, no transaction handle, no rows
+cursor** — a caller cannot construct SQL through it.
+
+`Games` and `Counts` take **the same `Query`**, which makes
+[`../blueprint/05-state-machine.md`](../blueprint/05-state-machine.md) §7 rule 2 enforceable: the
+summary describes the filtered set, so the list and the numbers above it cannot describe different
+sets. `Counts` ignores `Limit`/`Offset`, because the summary describes the set and not the page.
+
+`SetStatus` takes a `*Status` so that clearing an override is expressible at all — and it stamps
+`status_changed_at` on a clear, because a clear is a change the player made and Phase 4 needs a
+timestamp for it.
+
+`UpsertBatch` **never writes the manual status**. That invariant lives in the store rather than in a
+provider because the store is the only writer and therefore the only place it can be guaranteed.
+
+`ReconcileAbsence` takes a `RunID`. See [`06-divergences.md`](./06-divergences.md) §6 — the argument
+type **is** the tombstone guard.
+
+**No query shape exists that no screen needs.** The facets are the three `Z-07` renders plus a
+presence mode, because a filter language would be an abstraction with one consumer and the consumer
+is a bar with three chips.
+
+## 5 · The error taxonomy
+
+Thirteen kinds, each with a screen treatment, a catalogue key and an exit code, all asserted total by
+tests. Full reasoning in [`02-error-taxonomy.md`](./02-error-taxonomy.md).
+
+## 6 · Offline and staleness
+
+`aged.Value[T]` on every network-derived value, and **no freshness parameter on any read**. Full
+reasoning in [`04-concurrency-and-offline.md`](./04-concurrency-and-offline.md) §4.
+
+## 7 · The CLI
+
+Declared as data, golden-tested, with a written stability policy. Full surface in
+[`03-cli-surface.md`](./03-cli-surface.md).
+
+## 8 · The Phase 4 boundary
+
+Sketched, and its rule enforced by a reflection test rather than a paragraph.
+[`05-phase4-sketch.md`](./05-phase4-sketch.md).
+
+## 9 · Media types
+
+Not a seam, by ratified decision. [`06-divergences.md`](./06-divergences.md) §1.
+
+---
+
+## The three supporting seams
+
+**`Vault`** — keyed by `(provider, key)`, so forgetting one provider cannot reach another's secrets
+and `DeleteProvider` is a complete operation rather than a loop the caller has to get right. Nothing
+in the library file can hold a credential, because `SaveConnection` takes an `accountRef` and there
+is no method that could take a secret.
+
+**`Images`** — `Cover` takes no context and returns no error, because it never fetches and never
+blocks; `Warm` is the only method that touches the network and it returns immediately. A screen never
+learns the protocol, so adding Sixel later changes one implementation and no screen. `images.Null` is
+a **supported configuration**, not a fallback.
+
+**`Audio`** — `Cue` has no error and no context, for the same reason. `audio.Null` is the **default
+build**, so the silent path is exercised by every test run rather than being the branch that only
+fails on somebody's laptop. `State` distinguishes *not compiled*, *off*, *unavailable* and
+*overridden by the environment*, because `Z-09` must say which — those are four different facts and
+collapsing them tells a player their setting changed when it did not.

--- a/docs/api/01-seams.md
+++ b/docs/api/01-seams.md
@@ -69,8 +69,9 @@ So the hedge stays exactly as designed. Removing it because one risk receded wou
 lesson: a source that is named today can change its terms tomorrow, which is true of every source and
 is not a fact about IGDB.
 
-**The test of agnosticism:** the word IGDB appears in one package comment and in **no signature, type,
-field or constant**. The fake is keyed on **title and platform**, which is the shape a source that has
+**The test of agnosticism:** the word IGDB appears **only in comments** — seven occurrences across
+`metadata/metadata.go`, `fault/kind.go` and `fault/treatment.go` — and in **no signature, type, field
+or constant**. The fake is keyed on **title and platform**, which is the shape a source that has
 never heard of Steam would have — and therefore the shape a cartridge needs.
 
 **`Null` is production code, not a test helper.** Having no metadata is a designed state: the detail

--- a/docs/api/01-seams.md
+++ b/docs/api/01-seams.md
@@ -120,6 +120,13 @@ type **is** the tombstone guard.
 presence mode, because a filter language would be an abstraction with one consumer and the consumer
 is a bar with three chips.
 
+`Query.Empty` and `Query.Facets` are a **pair**, and the invariant that binds them — a query that
+reports itself filtered always names at least one facet — is asserted over the whole cross-product
+rather than case by case. It has to be: the contract's own idiom is
+`if !q.Empty() { name(q.Facets()[0]) }`, so a combination that reported itself filtered while naming
+nothing would index an empty slice. `Presence: Either` did exactly that until the review at
+`4484d9a`, and the repair was the invariant rather than the case.
+
 ## 5 · The error taxonomy
 
 Thirteen kinds, each with a screen treatment, a catalogue key and an exit code, all asserted total by

--- a/docs/api/02-error-taxonomy.md
+++ b/docs/api/02-error-taxonomy.md
@@ -1,0 +1,141 @@
+---
+title: Zerado — the error taxonomy
+discipline: API
+doc-no: ZRD-API-02
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: concept-explainer
+ticket: "#6"
+---
+
+# The error taxonomy
+
+One closed set of kinds, shared by every seam, each distinguishable by the caller **because each one
+renders differently on screen**.
+
+The requirement that shaped it, from the ticket: *a private Steam profile is NOT a network error and
+must not render as one.*
+
+---
+
+## 1 · Why that case is the whole design
+
+A private Steam profile is:
+
+- a **successful** HTTP request,
+- returning a **well-formed** body,
+- from a service that is **up**,
+- using a key that **works**.
+
+Every mechanism that would collapse it into "network error" — a bare error string, a status code, a
+boolean `ok` — produces a screen that tells the player their connection failed when their connection
+is fine, and sends them to debug the wrong thing.
+
+And it is worse than a bad message. [`../blueprint/06-data-seams.md`](../blueprint/06-data-seams.md)
+§2.4 forbids tombstoning on any run that is not `ok`, and `Z-03` §8.2 spells out the consequence: a
+247-game library whose owner has just made their profile private would be deleted by a naive "the
+provider's view is the truth" upsert, after which the screen would honestly report a catastrophe it
+had caused. **A caller that cannot tell "the provider returned nothing" from "the provider could not
+be reached" cannot honour that rule.**
+
+`fault.KindEmpty` exists so it can.
+
+---
+
+## 2 · The thirteen kinds
+
+| Kind | Cause | Treatment | Retryable | Exit | The screen |
+|---|---|---|---|---|---|
+| `offline` | no route · DNS | banner | **yes** | 3 | `OFFLINE` |
+| `unreachable` | timeout · 5xx · reset | banner | **yes** | 4 | `STEAM UNREACHABLE` |
+| `unauthorized` | 401 · 403 | refusal | no | 5 | `STEAM KEY REJECTED` |
+| `rate_limited` | 429, with the provider's wait | banner | **yes** | 7 | banner + the wait |
+| `empty` | 200 with zero items | refusal | no | 6 | `STEAM PROFILE PRIVATE` |
+| `not_found` | the source has never heard of it | **designed empty** | no | 8 | the no-metadata composition |
+| `malformed` | an answer we cannot read · a 4xx we caused | refusal | no | 9 | a refusal naming what we sent |
+| `stale` | a cached value too old to act on | banner | no | 10 | the amber banner |
+| `unsupported` | a capability the provider does not have | refusal | no | 10 | a refusal |
+| `precondition` | legal operation, wrong state | refusal | no | 10 | a refusal |
+| `conflict` | a uniqueness rule | refusal | no | 10 | a refusal |
+| `cancelled` | the player stopped it | **none** | no | 130 | `CANCELLED` — no cue, no red |
+| `internal` | our defect | **fatal** | no | 1 | `Z-11` |
+
+`TestTaxonomyIsTotal` asserts every kind has a distinct machine name, a treatment and a catalogue
+key. `TestExitCodesAreTotal` asserts every kind has an exit code that is not `0`. **Adding a kind
+without deciding what it looks like on screen, and what a script should do about it, fails CI.**
+
+---
+
+## 3 · The four network-ish failures do not collapse
+
+`TestTheFourNetworkFailuresDoNotCollapse` asserts that `offline`, `unreachable`, `unauthorized`,
+`empty` and `rate_limited` map to five **distinct** exit codes.
+
+The reason is a caller nobody thinks about at design time: a nightly `cron` line that runs
+`zerado sync`. It wants to retry on `offline`, back off on `rate_limited`, and alert a human on
+`unauthorized`. It cannot do any of that if all five are `1`.
+
+---
+
+## 4 · Three rules the type enforces
+
+### 4.1 · A fault carries a key, never a sentence
+
+ADR-0001 **D9** forbids user-facing string literals in code, and an error message is user-facing
+text. `Fault.MessageKey` is an `i18n.Key`; the `Kind` supplies a default and a provider may override
+it when it has genuinely better copy for its own case — Steam's private-profile refusal names a
+specific Steam privacy setting, which no provider-agnostic entry could.
+
+The subject travels as a **substitution**, not as part of the sentence. That is what makes one
+catalogue entry correct for Steam today and GOG later, in every language, with no new key.
+
+### 4.2 · The wrapped cause is never rendered
+
+`Fault.Error()` deliberately **does not include its cause**.
+
+This is a credential-disclosure guard, not a style preference. An `*url.Error` from `net/http`
+stringifies the whole URL, and Steam's URLs carry the player's API key as a query parameter. An
+error string that concatenated its cause would be a disclosure path running straight through the one
+screen a frustrated player is most likely to screenshot into a bug report.
+
+The cause stays reachable through `errors.Is`/`As` for a log sink that has been told it may see it.
+`TestErrorDoesNotLeakTheCause` and `TestTheEnvelopeCarriesNoMessage` assert both halves — the second
+one against the JSON envelope, which is the single most likely thing in this product to be piped
+into a file and attached to a bug report.
+
+### 4.3 · An unclassified error is `internal`, never a plausible guess
+
+`fault.KindOf` returns `KindInternal` for any non-`Fault` error. It does not guess `unreachable`.
+
+A scripted caller retrying forever because an internal panic was reported as a timeout is a worse
+outcome than a loud `1`, and a player told their network failed when a migration is corrupt has been
+sent to fix the wrong thing.
+
+---
+
+## 5 · The classifier is a pure function, and that is deliberate
+
+`fault.Classify` implements
+[`../blueprint/07-offline-contract.md`](../blueprint/07-offline-contract.md) §5's decision tree. It
+takes a `fault.Outcome` — a `Transport` verdict, a status code, an item count — and returns a
+`*Fault`.
+
+It does **not** take an `*http.Response` and does not import `net` or `net/http`. Two consequences,
+and the second is the one that mattered:
+
+1. The `fault` package stays outside the network rule's blast radius. §7.3's grep rule would
+   otherwise have been violated by its own most reasonable-looking helper, after which the rule is a
+   comment.
+2. **Every branch is reachable in a test with no network.** `TestClassifyFollowsTheOfflineContract`
+   walks all twelve.
+
+The branch order is part of the contract: transport first (a rejected key is meaningless if the
+request never arrived), then `401`/`403` (a credential verdict outranks anything derivable from the
+body), then `404` and `429`, then `5xx`, then any other `4xx` — which is **our** bug and not their
+outage, and must not be dressed as one.
+
+`ClassifySync` is separate from `Classify` because **emptiness is a refusal for exactly one
+operation**. A metadata lookup that finds nothing renders a designed composition; a price lookup
+that finds no quote is simply no quote. Only a library sync may conclude, from an empty answer, that
+the player has to go and change a setting somewhere else.

--- a/docs/api/02-error-taxonomy.md
+++ b/docs/api/02-error-taxonomy.md
@@ -65,6 +65,38 @@ be reached" cannot honour that rule.**
 key. `TestExitCodesAreTotal` asserts every kind has an exit code that is not `0`. **Adding a kind
 without deciding what it looks like on screen, and what a script should do about it, fails CI.**
 
+### 2.1 · That guarantee was false once, and how it was repaired
+
+The review at `c4c8d95` falsified it, empirically, and the falsification is worth keeping because the
+failure was in the enforcement layer rather than in the design.
+
+`Kinds()` was a **hand-maintained slice** while `Valid()` was **derived from the iota range**. Both
+totality tests iterated the slice, and nothing asserted the slice covered the range. So a kind
+inserted *mid-block* — the natural move, since the kinds are grouped semantically — was valid,
+constructible, and **invisible to every test that existed to catch exactly that**. Probed, it
+resolved to `String() == "unknown"` on a surface the CLI documents as stable API,
+`Treatment() == TreatmentFatal`, `MessageKey() == "fault.internal"` and exit `1`. CI stayed green.
+
+**The repair removes the second source of truth rather than adding a test to reconcile the two.**
+`Kinds()` is now derived from the same range as `Valid()`, so they cannot disagree. Four assertions
+were added on top, because deriving the set is only half of it — a kind that is *in* the set can
+still silently inherit a switch default:
+
+| Test | What it catches |
+|---|---|
+| `TestKindsCoversTheWholeRange` | a future contributor reintroducing a literal slice |
+| `TestNoKindFallsThroughToTheDefaults` | a kind with no case in `String`, `Treatment` or `MessageKey` |
+| `TestNoKindSilentlyInheritsTheInternalExitCode` | a kind with no case in `ExitCode` |
+| `TestTaxonomyIsTotal` | as before, now over a set that is actually complete |
+
+Verified by re-running the reviewer's own probe: inserting `KindThrottled` between `KindConflict` and
+`KindCancelled` now fails **four assertions across two packages**, by number, naming each missing
+case.
+
+Two doc comments that asserted the enforcement while it did not exist — `treatment.go` and
+`exit.go` — were corrected rather than quietly fixed. A comment claiming a guarantee the code does
+not provide is worse than no comment, because it is what a reviewer reads instead of the test.
+
 ---
 
 ## 3 · The four network-ish failures do not collapse

--- a/docs/api/02-error-taxonomy.md
+++ b/docs/api/02-error-taxonomy.md
@@ -90,8 +90,17 @@ still silently inherit a switch default:
 | `TestTaxonomyIsTotal` | as before, now over a set that is actually complete |
 
 Verified by re-running the reviewer's own probe: inserting `KindThrottled` between `KindConflict` and
-`KindCancelled` now fails **four assertions across two packages**, by number, naming each missing
-case.
+`KindCancelled` now fails **three assertions across two packages**, by number, naming each missing
+case — `TestTaxonomyIsTotal` and `TestNoKindFallsThroughToTheDefaults` in `fault`, and
+`TestNoKindSilentlyInheritsTheInternalExitCode` in `cli`.
+
+**Three, not four.** `TestKindsCoversTheWholeRange` cannot fire on a mid-block insert, and that is
+correct rather than a gap: it checks `Kinds()` against the range `Kinds()` is now derived from, so it
+guards the *other* probe — a future contributor reintroducing a literal slice. The table above says
+so; a claim of "four assertions" shipped alongside it in the PR body and the commit message, and was
+wrong. *(Refuted by the review at `fbef7f1`, which ran the probe rather than reading the claim.
+Corrected here rather than restated, because a bundle whose value is that its numbers are checked
+cannot carry an unchecked one about its own tests.)*
 
 Two doc comments that asserted the enforcement while it did not exist — `treatment.go` and
 `exit.go` — were corrected rather than quietly fixed. A comment claiming a guarantee the code does

--- a/docs/api/02-error-taxonomy.md
+++ b/docs/api/02-error-taxonomy.md
@@ -162,6 +162,25 @@ sent to fix the wrong thing.
 takes a `fault.Outcome` — a `Transport` verdict, a status code, an item count — and returns a
 `*Fault`.
 
+It returns `error`, not `*Fault` — and that is a repair rather than a stylistic choice. It returned
+`*Fault` once, which made the natural provider spelling a trap:
+
+```go
+func (s *steam) sync(...) error { return fault.Classify(o) }   // success → non-nil error
+```
+
+A successful outcome returned a nil `*Fault`, which becomes a **non-nil error interface holding a
+typed nil**. `KindOf` then finds `err != nil`, `errors.As` succeeds, the embedded pointer is nil — and
+reports `KindInternal`, so a **completely successful sync renders the fatal screen**.
+
+It failed in the safe direction, which is the taxonomy working. But safe is not correct, and the fix
+is the same one this package has now made twice: make the guarantee a property of the signature
+rather than of how carefully every caller holds it. Returning `error` means the nil is an *untyped*
+nil at every call site, including the ones nobody has written yet.
+`TestClassifySuccessIsAnUntypedNil` pins it through an error-returning function, because that
+conversion is what created the trap and a direct comparison against the concrete type would not have
+caught it.
+
 It does **not** take an `*http.Response` and does not import `net` or `net/http`. Two consequences,
 and the second is the one that mattered:
 

--- a/docs/api/03-cli-surface.md
+++ b/docs/api/03-cli-surface.md
@@ -1,0 +1,117 @@
+---
+title: Zerado — the CLI as a versioned API
+discipline: API
+doc-no: ZRD-API-03
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: implementation-plan
+ticket: "#6"
+---
+
+# The CLI verb surface
+
+A CLI is an API the moment anyone types it. A verb in somebody's shell history, a script parsing an
+exit code, a `cron` line — each is a caller with no upgrade path.
+
+So the surface is declared as **data** in `internal/cli`, with a golden test over it, and the
+stability policy is written down before there is anything to break.
+
+---
+
+## 1 · Phase 1
+
+| Verb | Arguments | Flags | Class |
+|---|---|---|---|
+| *(none)* | | | the TUI. Interactive |
+| `sync` | `[provider]` | `--all` | **NEEDS THE NETWORK** |
+| `list` | | `--state --source --search --absent --limit` | WORKS |
+| `mark` | `<game> <state>` | `--clear` | WORKS |
+| `add` | | `--title --platform --state --owned-since` | WORKS |
+| `game` | `<game>` | | WORKS. Interactive — the deep link |
+| `doctor` | | | WORKS |
+| `version` | | | WORKS |
+| `help` | `[verb]` | | WORKS |
+
+Global: `--json --quiet --db=path --no-color --version --help`.
+
+`TestOfflineClassIsDeclared` asserts that **only `sync`** claims to need the network. Everything else
+is a read of a local file, which is
+[`../blueprint/07-offline-contract.md`](../blueprint/07-offline-contract.md)'s classification
+expressed where a scripted caller can see it *before* running anything.
+
+### Two verbs that exist because a screen needed them
+
+**`mark --clear`.** Clearing an override is a different action from setting `NOT STARTED`
+([`../blueprint/05-state-machine.md`](../blueprint/05-state-machine.md) §5) — clearing on a game with
+playtime makes it `IN PROGRESS` immediately, while choosing `NOT STARTED` stores a value that
+sticks. A CLI without `--clear` could not do what `Z-06` does.
+
+**`game <id>`.** [`../blueprint/04-navigation-and-focus.md`](../blueprint/04-navigation-and-focus.md)
+notes that deep-linking requires the route stack to be constructible from a descriptor rather than
+only by pushing. That is a **Phase 1 constraint caused by this verb**, and it is recorded next to
+the verb that causes it.
+
+---
+
+## 2 · Reserved, and not half-working
+
+`tonight` · `price` · `watch` · `tag` · `enrich` · `devices` · `export` · `import`.
+
+The names are claimed so a Phase 1 user's script cannot come to depend on `zerado tonight` meaning
+something else, and so the eventual feature does not have to settle for a worse word.
+
+They declare **no arguments and no flags** — `TestReservedVerbsPromiseNothing` asserts it — because a
+reserved verb has no shape yet, and because copy that mentions a capability the build does not have
+presents something unbuilt as working.
+
+---
+
+## 3 · Exit codes
+
+`0` ok · `1` internal · `2` usage · `3` offline · `4` unreachable · `5` unauthorized · `6` empty ·
+`7` rate-limited · `8` not found · `9` malformed · `10` state · **`130` cancelled**.
+
+`130` borrows the shell's own convention for a process killed by `SIGINT`, so a player who pressed
+Ctrl-C sees the number they would have seen anyway.
+
+The mapping is total over the taxonomy and asserted by `TestExitCodesAreTotal`.
+
+---
+
+## 4 · `--json`
+
+One shape for success and failure, because a caller that has to parse two different top-level
+structures depending on an exit code will get it wrong on the day it matters.
+
+```json
+{"api":1,"ok":true,"data":{"games":247}}
+{"api":1,"ok":false,"error":{"kind":"offline","op":"steam.Sync","subject":"Steam",
+                             "message_key":"fault.offline","retry_after_seconds":0}}
+```
+
+**The envelope carries no message.** That is not an omission: a message is user-facing text rendered
+from the catalogue in the player's language, and a pre-rendered English sentence in a JSON field is
+the hardest D9 violation to spot. A consumer that wants a sentence renders one from the key; a
+consumer that wants to branch uses the kind, which is what it should have been using anyway.
+
+`retry_after_seconds` is a number rather than `"1m30s"`, because every JSON consumer can compare a
+number and not all of them can parse a duration string.
+
+---
+
+## 5 · The stability policy
+
+- `api` is the contract's **major** version and appears in every envelope.
+- **Fields are added, never removed and never repurposed.** A consumer that ignores unknown fields
+  keeps working across every minor change.
+- **A field's meaning is fixed.** Changing what `unchanged` counts is a breaking change even though
+  the JSON looks identical, and it bumps the version.
+- **Error kinds are the taxonomy's stable names.** Adding one is additive; a consumer that does not
+  recognise a kind must treat it as a failure rather than as success — which is why `ok` exists
+  separately from the kind.
+- **Exit codes and kinds move together** and are documented together.
+- **A verb is never renamed** within a major version. `TestVerbSurfaceIsStable` holds a golden list,
+  so a rename has to be a deliberate act that updates the test and says why in the diff.
+- Status values (`not_started` · `in_progress` · `zerado` · `abandoned`), provider ids, run statuses
+  and backing kinds are all **stored values as well as printed ones**. They are API twice over.

--- a/docs/api/03-cli-surface.md
+++ b/docs/api/03-cli-surface.md
@@ -47,6 +47,14 @@ expressed where a scripted caller can see it *before* running anything.
 playtime makes it `IN PROGRESS` immediately, while choosing `NOT STARTED` stores a value that
 sticks. A CLI without `--clear` could not do what `Z-06` does.
 
+Its arity needs `Arg.RequiredUnless`: `state` is required **unless `--clear` is present**. An earlier
+revision declared `state` flatly required alongside the flag, which meant the surface — read as data,
+which is the whole point of declaring it as data — rejected the invocation this paragraph says must
+work. A surface that contradicts its own stated requirement is worse than an incomplete one, because
+only whoever writes the parser discovers it. `TestTheSurfaceCanExpressEveryDocumentedInvocation` now
+runs the documented invocations against the declared arities, so the two cannot drift apart without
+one of them failing. *(Found by the review at `4484d9a`.)*
+
 **`game <id>`.** [`../blueprint/04-navigation-and-focus.md`](../blueprint/04-navigation-and-focus.md)
 notes that deep-linking requires the route stack to be constructible from a descriptor rather than
 only by pushing. That is a **Phase 1 constraint caused by this verb**, and it is recorded next to

--- a/docs/api/04-concurrency-and-offline.md
+++ b/docs/api/04-concurrency-and-offline.md
@@ -1,0 +1,158 @@
+---
+title: Zerado — context, concurrency and the offline contract in the signatures
+discipline: API
+doc-no: ZRD-API-04
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: concept-explainer
+ticket: "#6"
+---
+
+# Context, concurrency, and staleness
+
+Three properties the ticket asks to be visible **in the signatures** rather than in a convention.
+
+---
+
+## 1 · Context on everything that could ever block
+
+Every method that does I/O takes a `context.Context` as its first parameter — including every read
+on the `Store`, which in Phase 1 is microseconds against a local file.
+
+Two reasons, and neither is speculative:
+
+- **A filter re-runs on every keystroke.** `Z-07` filters live as the player types, and a query
+  whose successor has already been typed must be abandonable.
+- **A Phase 4 implementation of the same interface does real I/O.** An interface that has to grow
+  contexts later grows them in every caller at once.
+
+**Two methods deliberately take no context, and the absence is the guarantee:**
+
+| Method | Why no context |
+|---|---|
+| `images.Cover` | It never fetches and never blocks — it reads what the cache already holds. A function that cannot block has nothing to cancel, and a `ctx` parameter would be an invitation to make it blocking later |
+| `audio.Cue` | Fire-and-forget, non-blocking, no error. A cue that cannot play is silence |
+
+Both are the same rule from
+[`../blueprint/17-images.md`](../blueprint/17-images.md) §6 and
+[`../blueprint/12-audio.md`](../blueprint/12-audio.md) §6: **a missing cover, and a missed sound, are
+never worth a dropped frame.**
+
+---
+
+## 2 · Cancellation is a hard requirement, not politeness
+
+`Syncer.Sync` documents that cancelling `ctx` **must** abort in-flight I/O and close the stream
+promptly. `Z-03` lets the player press `Esc` mid-sync, `q` quits from anywhere immediately, and the
+goroutine budget for the whole product is **zero leaks** — so a provider that ignores cancellation
+does not merely delay a screen, it holds the process open at quit.
+
+`TestSyncStreams` cancels after the second of five items and asserts three things: some items
+arrived, not all of them did, and `Stream.Err()` reports `KindCancelled` rather than an
+unclassified error that would render as the fatal screen.
+
+The fake honours `ctx` **while sleeping as well as between items**, deliberately. A provider that
+only checked between items would pass a fast test and hang the product on a slow network — which is
+exactly the moment the player reaches for `Esc`.
+
+---
+
+## 3 · The concurrency shape, stated per return type
+
+| Returns | Where | Why |
+|---|---|---|
+| a **`Stream`** (channel + terminal error + progress) | `Syncer.Sync` | honest running counts; a cancel leaves a valid partial library; bounded memory at any library size |
+| a **slice** | `Store.Games`, `Store.Connections` | a bounded page of a local read. A channel here would buy nothing and cost every caller a `range` |
+| a **single value** | `metadata.Lookup`, `pricing.Quote` | one question about one game. The Phase 2 enrichment pass is the caller that runs many concurrently, and it owns the worker count — not the interface |
+| **nothing** | `images.Warm`, `audio.Cue` | fire-and-forget, off the render path, bounded by a pool the seam owns |
+
+**No interface takes a worker count.** Fan-out is the caller's decision because only the caller knows
+whether it is enriching twelve visible rows or all 247, and an interface parameter would push a
+rate-limiting policy into a signature that a second provider would need differently.
+
+### 3.1 · Why `Sync` returns a `Stream` and not a bare channel
+
+The spine's shape was `Sync(ctx, c) (<-chan Item, error)`. It carries the failure that is known
+before anything arrives and has **nowhere to put the failure that happens after** — which is
+`PARTIAL`, one of `Z-03`'s four terminal states.
+
+`Stream` adds exactly two things to the channel:
+
+- **`Err()`**, valid after the channel closes. The `sql.Rows` pattern.
+- **`Progress()`**, a race-free snapshot.
+
+`Progress` is what `Z-03` §3.1 needs and a channel cannot supply: the **denominator**. A channel of
+items cannot say "247 are coming", so without it the screen draws an indeterminate scanner forever
+and never earns its determinate bar.
+
+`Progress()` is documented as safe to call from another goroutine at any time. That is a hard
+requirement, not a nicety — the caller is a Bubble Tea render loop reading it once per frame while
+the provider's goroutine writes. `TestProgressIsReadableWhileTheSyncRuns` does exactly that and the
+suite passes under `-race`.
+
+Two details in `Progress` that a screen would otherwise get wrong:
+
+- **`TotalKnown` is a separate field from `Total`,** because zero is a real total — it is the
+  private-profile case — and a screen reading `0` as "unknown" would scan forever for a sync that
+  has truthfully finished. `TestAZeroTotalIsNotUnknown`.
+- **`LastAt` is provided; "stalled" is not.** Whether a ten-second pause is alarming is a screen's
+  judgement about a player's patience, not a provider's judgement about a socket.
+  `TestStalledIsNotWaiting` pins the distinction that a sync which has delivered nothing yet is
+  *waiting*, which already has its own component.
+
+---
+
+## 4 · The offline and staleness contract, in the signatures
+
+### 4.1 · There is no freshness parameter on any read
+
+The obvious way to express staleness in an API is a policy argument — `CachedOnly`, `PreferCached`,
+`ForceFresh`. **The `Store` interface has none.**
+
+A read cannot reach the network under any policy. What a caller gets is what is local, stamped with
+when it was observed; the only way to make it fresher is an explicit sync, which is an action with a
+screen and a key behind it.
+
+That absence **is** the offline contract expressed in the signatures. A `ForceFresh` option would be
+a hole through which a render path could start a network request, and §7.3's grep rule would then be
+guarding a door with a window next to it.
+
+### 4.2 · `aged.Value[T]` makes the age impossible to drop
+
+> Any value that came from the network is rendered with its age. Always.
+
+[`../blueprint/07-offline-contract.md`](../blueprint/07-offline-contract.md) §4 names this as the
+rule most likely to be lost during a build, because dropping the age always makes the layout tidier.
+It is also the rule the product's credibility rests on: Zerado's value proposition is telling a
+player **not** to buy something, and a stale price presented as current is the product giving
+financial advice from memory.
+
+Every network-derived value is returned inside `aged.Value[T]`. **There is no way to reach the
+payload without having the age in hand** — a `FetchedAt` field can be ignored by a renderer; a
+wrapper cannot.
+
+`aged.Map` exists to close the one loophole: transforming a value and re-stamping it as new, in code
+that looks entirely reasonable. `TestMapKeepsTheObservationTime`.
+
+`Classify` has three bands because the design system has three behaviours — nothing, the banner as
+chrome, and amber past **ninety days** (§4.1). `aged.WarnAfter` is a constant of the contract rather
+than a setting, because a threshold a caller can lower is a threshold that gets lowered to make a
+banner go away.
+
+A value stamped in the **future** — a source clock ahead of this machine — clamps to zero. "In 3
+hours" next to a price would be the product reporting somebody else's NTP problem as a feature.
+
+### 4.3 · Three facts about playtime, not two
+
+`Z-05` renders three different things where a nullable column and a zero would give two:
+
+| Screen | Fact | Mechanism |
+|---|---|---|
+| `not tracked` | the provider cannot ever know | `Capabilities.Playtime == false` |
+| `—` | not fetched yet | the pointer is `nil` |
+| `0h` · `never played` | the provider answered, and the answer was nothing | the pointer is set, to zero |
+
+The capability answers the first; the pointer answers the second and third. Collapsing either
+produces a screen that tells a player their cartridge has been played for zero hours — a claim
+nothing could have made. `TestGameDistinguishesThreeFactsAboutPlaytime`.

--- a/docs/api/05-phase4-sketch.md
+++ b/docs/api/05-phase4-sketch.md
@@ -1,0 +1,76 @@
+---
+title: Zerado — the Phase 4 sync boundary, sketched
+discipline: API
+doc-no: ZRD-API-05
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: concept-explainer
+ticket: "#6"
+---
+
+# The Phase 4 boundary
+
+**Sketch only. Nothing is built and no Phase 1 code calls it.**
+
+It exists because ADR-0001 **D4** decides *what crosses* now rather than in Phase 4, and because that
+is the most expensive decision in the bundle to reverse: it decides what the schema carries from the
+first migration onward.
+
+---
+
+## 1 · The rule
+
+> **Only what the player typed crosses. Everything a machine can recompute, each device
+> recomputes.**
+
+| Crosses | Never crosses |
+|---|---|
+| the manual status + when it changed | the library itself |
+| hand-entered games — the one row class with no other copy | `playtime_minutes` · `last_played_at` |
+| a stable cross-device identity | cover art · *sinopse* |
+| mood tags the player assigned (Phase 2) | prices |
+| | **credentials. Ever.** |
+
+---
+
+## 2 · The rule is a test, not a paragraph
+
+`TestPayloadCarriesOnlyWhatThePlayerTyped` walks the payload structs by reflection against an
+allow-list. `TestNothingResemblingACredentialCanCross` fails on any field whose name contains `key`,
+`token`, `secret`, `password`, `credential`, `auth`, `cookie` or `session`.
+
+The reason is a specific, likely future. In 2027, in a Phase 4 sprint, long after everyone who read
+D4 has moved on, adding playtime to the payload will look like an obvious improvement — the server
+already has the rows and showing hours on another device is a nice feature. A paragraph will not
+stop it. A test that fails by name, with the decision quoted in the failure message, will.
+
+---
+
+## 3 · What Phase 1 must not make impossible — and does not
+
+| Needed in Phase 4 | Present in Phase 1 | Cost of adding it later |
+|---|---|---|
+| a stable cross-device identity (`library.UID`) | assigned at insert, indexed, **not unique** | a migration that has to invent identities for rows whose titles the player has since edited |
+| `status_changed_at`, written on **every** change including a clear | `Store.SetStatus` stamps it, always | conflicts unresolvable for every pre-existing row |
+| `merged_into` | on `library.Game`, excluded from every query | a migration that rewrites primary keys |
+| a single writer to attach to | `store.Store` is the only writer | a merge engine that has to find every write path |
+
+`TestAClearedOverrideCanCross` asserts `Change.Status` is a pointer: *"I have no opinion"* is a change
+the player made, and a non-nullable field would make a clear unsyncable — after which the player's
+two devices disagree with themselves forever.
+
+---
+
+## 4 · Two calls, and why not more
+
+`Push` and `Pull`. The payload is small and idempotent, and anything richer — a subscription, a
+stream, an operation log, CRDTs — would be designing for a conflict shape that does not exist. D4
+rejects those for the stated reason: they are correct for concurrent multi-writer editing, and the
+conflicting parties here are **one person on two devices who agree about what they did.**
+
+`Receipt` reports `Accepted` and `Superseded` because last-write-wins is an acceptable simplicity
+choice only if it is not a silent one — `Z-22` shows the last merge and what it resolved.
+
+**Not decided here, and named so it is not assumed to have been:** whether Phase 4 accounts are
+email-and-password, OAuth or something else. Nothing in Phase 1 depends on it.

--- a/docs/api/06-divergences.md
+++ b/docs/api/06-divergences.md
@@ -121,13 +121,25 @@ player finished a game. `TestOnlyAnOkRunMayTombstone` runs it for `partial`, `fa
 
 ## 7 · `Capabilities.Playtime`, not `Capabilities.Progress`
 
-`Z-08` §3.1 and `Z-05` D4 both write `Capabilities.Progress`. That is the **withdrawn** generic-progress
-model from revision A: ADR-0001 D5 states *"the generic-progress divergence is withdrawn"* and the
-ERD makes `playtime_minutes` a plain column.
+`Capabilities.Progress` is the **withdrawn** generic-progress model from revision A: ADR-0001 D5
+states *"the generic-progress divergence is withdrawn"* and the ERD makes `playtime_minutes` a plain
+column. The blueprint spells it `Playtime`. **`Playtime` wins**, being the ratified one.
 
-The blueprint spells it `Playtime` and the screens spell it `Progress`. **`Playtime` wins**, being the
-ratified one. Two screen specs carry a stale field name and should be corrected on their next
-revision — recorded here rather than edited from this ticket, which does not own them.
+**Four screen specs still carry the withdrawn name, at five sites.** Enumerated rather than
+summarised, so the follow-up catches all of them:
+
+| Spec | Line |
+|---|---|
+| `../design/screens/Z-04-library.md` | 1027 |
+| `../design/screens/Z-05-game-detail.md` | 399 |
+| `../design/screens/Z-06-set-status.md` | 366 |
+| `../design/screens/Z-08-add-a-game-by-hand.md` | 75, 375 |
+
+Recorded here rather than edited from this ticket, which does not own those specs.
+
+*(An earlier revision of this section recorded **two**. The review at `c4c8d95` grepped and found
+four, which left two stale specs unrecorded — a completeness defect in the one document whose whole
+job is completeness. The list above is the grep output, not a recollection.)*
 
 ## 8 · `Item.PlaytimeMinutes` is a pointer
 

--- a/docs/api/06-divergences.md
+++ b/docs/api/06-divergences.md
@@ -1,0 +1,153 @@
+---
+title: Zerado — divergences from the spine's shapes
+discipline: API
+doc-no: ZRD-API-06
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: adr-detail
+ticket: "#6"
+---
+
+# Divergences
+
+[`../blueprint/13-handoffs.md`](../blueprint/13-handoffs.md) §2 says this deliverable *"should feel
+free to change every name in this bundle"* and lists seven decisions it must not change **by
+accident**. This document is the accident-prevention mechanism: every departure, named, with the
+decision it preserves and the reason it departed.
+
+**First, the seven that are unchanged**, since the list exists to be checked rather than trusted:
+
+| Load-bearing decision | Where it lives now |
+|---|---|
+| `physical` implements `Provider` and **not** `Syncer` | `providertest.Manual`, asserted by `TestManualIsNotASyncer` |
+| everything downstream reads **`Capabilities`**, never an ID | `provider.Capabilities`, asserted by `provider.Check` |
+| `Sync` **streams**, so a cancel leaves a valid partial library | `provider.Stream`, asserted by `TestSyncStreams` |
+| every network-derived value carries **its own age** | `aged.Value[T]` — strengthened, see §2 |
+| `Quote` carries **no affiliate URL**, and every quote carries its age | `pricing.Quote` — there is no field that could hold one |
+| `Audio.Cue` **cannot fail and cannot block** | `audio.Audio.Cue` — no error, no context |
+| `Store` is the only writer; screens only read | `store.Store`, asserted by `internal/arch` |
+
+---
+
+## 1 · Media-type polymorphism: the ticket asks for a seam, the ADR forbids one
+
+**The ticket's item 9** asks for *"the seams that must be generic so books, and possibly films and
+TV, plug in without reshaping anything."*
+
+**ADR-0001 D5 pruned that**, by founder direction on 2026-08-25: *"At this point don't even think on
+books and other media types. What I would like is let that door open."*
+[`../blueprint/06-data-seams.md`](../blueprint/06-data-seams.md) §7 lists a media-type abstraction as
+explicitly **not a seam** — *"an interface parameterised on a type that has one value is machinery
+without a purpose"* — and [`../blueprint/11-media-model.md`](../blueprint/11-media-model.md) records
+that the speculation had begun to shape Phase 1 tables and Phase 1 states, which is the cost that
+makes speculative generality expensive rather than merely unused.
+
+**Resolution: the ratified ADR wins, and the disagreement is surfaced rather than silently
+resolved.** `library.Game` has no type parameter and no media-type field.
+
+What answers the ticket's *intent* — that a second media type must not require reshaping anything —
+is that the affordance lives in the schema and costs nothing above it: the entity is `item` carrying
+an `item_type` constrained to `'game'`. Adding a second type is one `CHECK` constraint. **No
+interface changes**, because nothing above the store reads a media type today and nothing would need
+to.
+
+*Escalated as a finding, per the brief's instruction to escalate rather than reopen.*
+
+## 2 · The age moves from a field into a wrapper
+
+**Spine shape:** `Metadata.FetchedAt`, `Quote.ObservedAt`.
+**Here:** `aged.Value[Metadata]`, `aged.Value[Quote]`.
+
+The load-bearing decision — *every network-derived value carries its own age in the same value* — is
+**preserved and strengthened**. A field can be ignored by a renderer; a wrapper cannot, because there
+is no way to reach the payload without having the age in hand.
+
+The cost is one `.V` at each call site. The moment it pays for itself is the only moment it is ever
+tested: a developer at 1am adding a column to a row, for whom dropping the age makes the layout
+tidier.
+
+*(This is a generic type, and it is worth saying why it does not contradict §1: the prohibition is on
+parameterising a **seam** over a media type that has one value. `aged.Value[T]` is a utility over
+any payload, with several instantiations already.)*
+
+## 3 · `Sync` returns a `Stream`, not a bare channel
+
+**Spine shape:** `Sync(ctx, c) (<-chan Item, error)`.
+
+The `error` return carries a failure known *before* anything arrives and has nowhere to put one that
+happens *after* — which is `PARTIAL`, one of `Z-03`'s four terminal states, so it cannot be
+inexpressible. `Stream` adds `Err()` after close and `Progress()`, the latter being the denominator
+`Z-03` §3.1 needs to draw a determinate bar at all. Reasoned in full in
+[`04-concurrency-and-offline.md`](./04-concurrency-and-offline.md) §3.1.
+
+## 4 · `Enterer` is a new interface the spine did not name
+
+The spine has `Provider` and `Syncer`, and describes hand entry as *"`Z-08` writing an `Item`
+directly"*.
+
+Written that way, two rules that make a hand-entered row a real row would live in a **screen**: that
+its `provider_ref` is a UUID Zerado mints rather than something the player has to find, and that its
+optional fields respect the provider's own capabilities. `Enterer` puts them in the provider, which
+is where they belong and where a second hand-enterable source inherits them.
+
+It is a **capability, not a provider kind**: a future GOG that syncs *and* lets a player add a game
+its API missed implements both, and `Z-08` gains a source picker rather than a special case.
+
+## 5 · `Vault.Backing()` returns a struct, not a string
+
+**Spine shape:** `Backing() string` — `"keychain"` or `"file"`.
+
+`Z-09` §10's copy is *"In the macOS Keychain"* · *"In the GNOME keyring"* · *"In Windows Credential
+Manager"* — three values a two-valued string cannot distinguish. The alternative is a screen
+switching on `runtime.GOOS`, which is right by coincidence and **wrong inside a container**.
+
+`vault.Backing{Kind, NameKey, Path}` lets the vault report what it actually opened. `Path` is there
+because Settings shows the file's location so the player can find, inspect and delete it.
+
+## 6 · `Store` gains `StartRun`/`FinishRun`, and `ReconcileAbsence` takes a run
+
+**Spine shape:** `RecordSyncRun(ctx, r SyncRun)`.
+
+A single record-at-the-end call cannot represent a sync that was **killed** — the ERD distinguishes
+that from *cancelled* by `finished_at` being null, and `Z-11`-adjacent honesty depends on it. So the
+run is opened before the first item is written.
+
+`ReconcileAbsence` takes a `RunID` rather than a `ProviderID`, and that is **the guard rather than a
+style choice**. Only a run whose status is `ok` may tombstone anything (§2.4). Passing a provider id
+would have made the illegal call *spellable* — and the illegal call deletes the evidence that a
+player finished a game. `TestOnlyAnOkRunMayTombstone` runs it for `partial`, `failed` and
+`cancelled` and asserts the refusal and that nothing was marked.
+
+## 7 · `Capabilities.Playtime`, not `Capabilities.Progress`
+
+`Z-08` §3.1 and `Z-05` D4 both write `Capabilities.Progress`. That is the **withdrawn** generic-progress
+model from revision A: ADR-0001 D5 states *"the generic-progress divergence is withdrawn"* and the
+ERD makes `playtime_minutes` a plain column.
+
+The blueprint spells it `Playtime` and the screens spell it `Progress`. **`Playtime` wins**, being the
+ratified one. Two screen specs carry a stale field name and should be corrected on their next
+revision — recorded here rather than edited from this ticket, which does not own them.
+
+## 8 · `Item.PlaytimeMinutes` is a pointer
+
+The spine's `Item` already made optional fields pointers, and this keeps that. It is listed because
+one consequence is a rule rather than a type: **a provider whose `Capabilities.Playtime` is false
+must always send `nil`.** Sending a zero would feed `status.Derive` a number it would treat as
+evidence — which is precisely the failure the capability model exists to prevent.
+
+## 9 · `Store` reads have no freshness parameter
+
+Not a departure from a spelling but from an expectation, recorded because a reviewer will look for
+one. Reasoned in [`04-concurrency-and-offline.md`](./04-concurrency-and-offline.md) §4.1.
+
+## 10 · Package layout
+
+`internal/`, one package per seam, with `fault`, `i18n`, `status` and `aged` as leaves that import
+nothing but the standard library and each other in one direction.
+
+`internal/` because ADR-0001 D1 rejects plugins: providers ship in the binary, so nothing outside
+this module ever needs to implement these interfaces. Making them public would be publishing an API
+with no consumer and no upgrade path.
+
+`internal/arch` holds no code — only the tests that keep the import graph honest.

--- a/docs/api/07-open-questions.md
+++ b/docs/api/07-open-questions.md
@@ -47,11 +47,13 @@ type is `library.UID` and **nothing above the store sees the column name**, so t
 `fft-database`'s to settle. Flagged only because two ratified documents spell it differently and the
 next reader should know that is a known inconsistency rather than a clue.
 
-## 4 · `Capabilities.Progress` in two screen specs
+## 4 · `Capabilities.Progress` in **four** screen specs
 
-`Z-08` §3.1 and `Z-05` D4 name a field that ADR-0001 D5 withdrew. The contract uses `Playtime`. The
-screen specs should be corrected on their next revision; this ticket does not own them.
-See [`06-divergences.md`](./06-divergences.md) §7.
+`Z-04` (line 1027), `Z-05` (399), `Z-06` (366) and `Z-08` (75, 375) name a field that ADR-0001 D5
+withdrew. The contract uses `Playtime`. Those specs should be corrected on their next revision; this
+ticket does not own them.
+
+Full list and the reason the count changed: [`06-divergences.md`](./06-divergences.md) §7.
 
 ## 5 · The D9 lint's exact implementation
 

--- a/docs/api/07-open-questions.md
+++ b/docs/api/07-open-questions.md
@@ -1,0 +1,88 @@
+---
+title: Zerado — what these contracts did not decide
+discipline: API
+doc-no: ZRD-API-07
+rev: A
+date: 2026-08-25
+status: draft — for review
+archetype: project-brief
+ticket: "#6"
+---
+
+# Open questions
+
+Named so they are not assumed to have been settled.
+
+---
+
+## 1 · Which audio library keeps the **default** build pure Go
+
+**Assigned to this ticket** by [`../blueprint/13-handoffs.md`](../blueprint/13-handoffs.md) §4, and
+**not answered here.**
+
+The handoff itself states the requirement: it *"needs a real per-platform check of cgo dependency,
+not an assumption."* That is a verification against six build targets, not a signature decision, and
+answering it from memory is exactly the failure this bundle's own review register keeps catching.
+
+**It blocks nothing.** ADR-0001 D6 puts the implementation behind a build tag; `audio.Null` is the
+**default** build and is what `internal/audio` ships. Whichever library is chosen changes **no
+signature in `audio.Audio`** — which is what the build-tag seam was designed to guarantee, and is the
+test of whether the seam is right.
+
+**Owner:** this ticket's follow-up, or the Phase 1 audio implementation ticket. **What it needs:** a
+per-platform check of each candidate's cgo dependency on darwin/arm64, darwin/amd64, linux/amd64,
+linux/arm64, windows/amd64.
+
+## 2 · The `library.UID` normalisation rules
+
+`fft-database`'s, per §4 of the handoff: it needs testing against a real library's titles. The
+**policy** is decided and is carried in the Go doc comment — a merge *hint*, never authoritative,
+indexed and not unique, with ambiguous matches shown to the player rather than guessed.
+
+## 3 · The column name for the cross-device identity
+
+[`../blueprint/09-erd.md`](../blueprint/09-erd.md) calls it `item_uid`;
+[`../blueprint/06-data-seams.md`](../blueprint/06-data-seams.md) §6.2 calls it `game_uid`. The Go
+type is `library.UID` and **nothing above the store sees the column name**, so this is
+`fft-database`'s to settle. Flagged only because two ratified documents spell it differently and the
+next reader should know that is a known inconsistency rather than a clue.
+
+## 4 · `Capabilities.Progress` in two screen specs
+
+`Z-08` §3.1 and `Z-05` D4 name a field that ADR-0001 D5 withdrew. The contract uses `Playtime`. The
+screen specs should be corrected on their next revision; this ticket does not own them.
+See [`06-divergences.md`](./06-divergences.md) §7.
+
+## 5 · The D9 lint's exact implementation
+
+[`../blueprint/16-i18n.md`](../blueprint/16-i18n.md) §1.1 assigns the lint's shape here and requires
+that it *exist, run in CI, and fail the build*.
+
+**What is decided and shipped:** the type it enforces against. `i18n.Key` exists; `fault.Fault`
+carries a key and never a sentence; `metadata.Attribution` carries a key, with `Verbatim` as the one
+sanctioned exception for wording a licence requires unaltered; every CLI verb and flag carries a
+`SummaryKey`, asserted by `TestEveryVerbHasACatalogueKey`.
+
+**What is not:** the lint binary itself. It is a build-tooling deliverable — a `go/analysis` pass
+over render and format calls with an explicit allow-list — and it needs a render path to analyse.
+There is not one yet. **Owner:** the Phase 1 TUI ticket that creates the first render path.
+
+## 6 · The `--json` payload shapes per verb
+
+The envelope is fixed and versioned. What `data` contains for `list` and `doctor` is defined when
+those verbs are built, and is **additive** under the §5 stability policy in
+[`03-cli-surface.md`](./03-cli-surface.md).
+
+## 7 · Two things ADR-0001 names as not decided, restated so they are not assumed
+
+- **Which metadata provider Phase 2 ships with.** The seam is decided; the provider is not.
+- **Whether Phase 4 accounts are email-and-password, OAuth or something else.** Nothing in Phase 1
+  depends on it.
+
+## 8 · Withdrawn from this ticket's scope
+
+A shared, product-agnostic **filterable table component contract** was added to this ticket by relay
+on 2026-08-25 and **withdrawn by a later relay the same day** (*"forget about the help screen, too
+much noise… I'll create that on flowforge side"*), with ticket #8 closed. Nothing of it remains in
+this branch — recorded here so that a reader who finds the instruction in the session history knows
+it was dropped deliberately rather than forgotten.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,19 @@
 module github.com/JustCode-CruzAlex/Zerado
 
-go 1.24
+// A full toolchain version (1.X.Y), not a bare language version.
+//
+// `go 1.24` is a LANGUAGE version. Go cannot resolve a toolchain from it —
+// `GOTOOLCHAIN=go1.24 go env GOROOT` fails with "go1.24 is a language version
+// but not a toolchain version" — which stopped the review vehicle before it
+// reached any code, and which Sprint 0 #10's acceptance criteria already
+// required ("go.mod declares the module and a pinned Go toolchain version").
+//
+// 1.27.0 is the toolchain this project is developed and reviewed on, so it
+// resolves locally with no download on every review and every build. A
+// contributor on an older Go switches to it automatically — that is what the
+// toolchain directive is for since 1.21 — so raising the floor costs one
+// transparent download rather than a build failure.
+//
+// The CI workflow reads this line via go-version-file rather than repeating
+// the number, so there is one place to change it and no drift.
+go 1.27.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/JustCode-CruzAlex/Zerado
+
+go 1.24

--- a/internal/aged/aged.go
+++ b/internal/aged/aged.go
@@ -1,0 +1,150 @@
+// Package aged carries the mechanism behind the product's single most
+// fragile promise: that any value which came from the network is rendered
+// with its age, always.
+//
+// 07-offline-contract.md §4 states the rule and names why it is the one most
+// likely to be lost during a build — dropping the age always makes the layout
+// tidier. It is also the rule the product's credibility rests on, because
+// Zerado's value proposition is telling a player *not* to buy something, and a
+// stale price presented as current is not a cosmetic defect but the product
+// giving financial advice from memory.
+//
+// # Why a wrapper type rather than a FetchedAt field
+//
+// The spine's shape put the age inside the payload — Metadata.FetchedAt,
+// Quote.ObservedAt. That satisfies "carries its own age in the same value",
+// and 13-handoffs.md §2 lists exactly that decision as load-bearing.
+//
+// [Value] keeps the decision and strengthens its enforcement. A field can be
+// ignored by a renderer; a wrapper cannot, because there is no way to reach
+// the payload without having the age in hand. The distinction matters at the
+// only moment it is ever tested — a developer at 1am adding a column to a
+// row — and the cost is one .V.
+//
+// Recorded as a deliberate departure in docs/api/06-divergences-from-the-spine.md
+// rather than applied quietly, because 13-handoffs.md §2's whole point is that
+// changing one of those decisions by accident is the failure to avoid.
+package aged
+
+import "time"
+
+// Value pairs a payload with the moment it was observed.
+//
+// Every network-derived value in Zerado is carried in a Value. A function that
+// returns a bare Quote or a bare Metadata is a bug in the contract, not a
+// convenience.
+//
+// The zero Value is meaningful and is not a trap: At is the zero time, which
+// [Value.Known] reports as unknown, and every helper on this type treats an
+// unknown age as "do not claim freshness". A value that arrived with no
+// timestamp is never presented as current.
+type Value[T any] struct {
+	// V is the payload.
+	//
+	// One letter, against Go's usual preference for descriptive names,
+	// because the type is a wrapper that appears at every network-derived
+	// read and the alternative — q.Value.Current — reads worse than
+	// q.V.Current at every one of those sites. The name that matters here is
+	// the type's.
+	V T
+
+	// At is when the payload was observed at its source.
+	//
+	// Observed, not fetched into the cache and not written to the database:
+	// the age a player is owed is the age of the *fact*, and a cache that
+	// re-stamps a value on copy would make a six-month-old price look like it
+	// arrived this morning.
+	At time.Time
+}
+
+// New stamps a payload with an observation time.
+func New[T any](v T, at time.Time) Value[T] { return Value[T]{V: v, At: at} }
+
+// Known reports whether this value carries a usable observation time.
+//
+// An unknown age is not an error — a value can legitimately predate the rule,
+// or arrive from a source that does not stamp its data. It is a rendering
+// instruction: 07 §4 permits no bare number, so a value whose age is unknown
+// is rendered as unknown rather than as fresh.
+func (v Value[T]) Known() bool { return !v.At.IsZero() }
+
+// Age returns how old the value is as of now.
+//
+// It returns zero for an unknown age. Callers must consult [Value.Known]
+// before treating a zero age as "just now"; every helper in this package that
+// classifies age does so already.
+//
+// A negative age — a source clock ahead of this machine's — is clamped to
+// zero. A value from the future is a clock-skew fact about two machines, not
+// information about the data, and rendering "in 3 hours" next to a price would
+// be the product reporting somebody else's NTP problem as a feature.
+func (v Value[T]) Age(now time.Time) time.Duration {
+	if !v.Known() {
+		return 0
+	}
+	if d := now.Sub(v.At); d > 0 {
+		return d
+	}
+	return 0
+}
+
+// Freshness is the coarse classification a screen switches on.
+//
+// Three bands, because the design system has three behaviours: nothing, the
+// banner as chrome, and the banner as something the player should act on
+// (07 §4.1 — past 90 days an age stops being reassuring and becomes a
+// warning). A finer scale would be a scale no screen could use.
+type Freshness uint8
+
+const (
+	// FreshnessUnknown means the value carries no observation time.
+	FreshnessUnknown Freshness = iota
+
+	// FreshnessCurrent means the value is within the caller's stated window.
+	FreshnessCurrent
+
+	// FreshnessStale means the value is older than the caller's window and
+	// younger than the warning threshold. It renders with its age, as chrome.
+	FreshnessStale
+
+	// FreshnessAncient means the value is past the warning threshold. The
+	// banner turns amber and names what the player should do.
+	FreshnessAncient
+)
+
+// WarnAfter is the age past which a value stops being merely stale and starts
+// being a warning: ninety days, from 07-offline-contract.md §4.1.
+//
+// It is a constant of the contract rather than a setting, because a threshold
+// a caller can lower is a threshold that gets lowered to make a banner go
+// away.
+const WarnAfter = 90 * 24 * time.Hour
+
+// Classify places the value in one of the three bands.
+//
+// window is the caller's own notion of current — a library sync is current for
+// hours, a price for minutes. The warning threshold is not the caller's to
+// choose.
+func (v Value[T]) Classify(now time.Time, window time.Duration) Freshness {
+	if !v.Known() {
+		return FreshnessUnknown
+	}
+	age := v.Age(now)
+	switch {
+	case age >= WarnAfter:
+		return FreshnessAncient
+	case age > window:
+		return FreshnessStale
+	default:
+		return FreshnessCurrent
+	}
+}
+
+// Map applies f to the payload and keeps the observation time.
+//
+// It exists so that a caller transforming a value cannot accidentally
+// re-stamp it as new — which is the single way this whole mechanism is
+// defeated, and it is defeated by code that looks entirely reasonable.
+func Map[A, B any](v Value[A], f func(A) B) Value[B] {
+	return Value[B]{V: f(v.V), At: v.At}
+}

--- a/internal/aged/aged.go
+++ b/internal/aged/aged.go
@@ -21,7 +21,7 @@
 // only moment it is ever tested — a developer at 1am adding a column to a
 // row — and the cost is one .V.
 //
-// Recorded as a deliberate departure in docs/api/06-divergences-from-the-spine.md
+// Recorded as a deliberate departure in docs/api/06-divergences.md
 // rather than applied quietly, because 13-handoffs.md §2's whole point is that
 // changing one of those decisions by accident is the failure to avoid.
 package aged

--- a/internal/aged/aged_test.go
+++ b/internal/aged/aged_test.go
@@ -1,0 +1,82 @@
+package aged_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+)
+
+var now = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+// TestAnUnstampedValueIsNeverCurrent is the age rule's floor: a value that
+// arrived with no timestamp is rendered as unknown, never as fresh. Dropping
+// the age always makes a layout tidier, which is why the type refuses to let
+// an unknown age look like a recent one.
+func TestAnUnstampedValueIsNeverCurrent(t *testing.T) {
+	var v aged.Value[int]
+	if v.Known() {
+		t.Fatal("the zero Value claims to know when it was observed")
+	}
+	if got := v.Classify(now, time.Hour); got != aged.FreshnessUnknown {
+		t.Fatalf("an unstamped value classified as %v", got)
+	}
+	if got := v.Age(now); got != 0 {
+		t.Fatalf("Age of an unstamped value = %v", got)
+	}
+}
+
+// TestClassifyBands walks the three behaviours the design system has: nothing,
+// the banner as chrome, and the banner as something to act on past ninety days
+// (07-offline-contract.md §4.1).
+func TestClassifyBands(t *testing.T) {
+	cases := []struct {
+		name   string
+		at     time.Time
+		window time.Duration
+		want   aged.Freshness
+	}{
+		{"a price fetched a minute ago", now.Add(-time.Minute), time.Hour, aged.FreshnessCurrent},
+		{"a price fetched yesterday", now.Add(-24 * time.Hour), time.Hour, aged.FreshnessStale},
+		{"a library synced three days ago", now.Add(-72 * time.Hour), 6 * time.Hour, aged.FreshnessStale},
+		{"a library last synced in May", now.Add(-100 * 24 * time.Hour), 6 * time.Hour, aged.FreshnessAncient},
+		{"exactly ninety days", now.Add(-aged.WarnAfter), time.Hour, aged.FreshnessAncient},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := aged.New(42, c.at)
+			if got := v.Classify(now, c.window); got != c.want {
+				t.Fatalf("Classify = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestAFutureValueIsNotRenderedAsFuture: a source clock ahead of this machine
+// is two machines disagreeing about NTP, not information about the data.
+// "In 3 hours" next to a price would be the product reporting somebody else's
+// problem as a feature.
+func TestAFutureValueIsNotRenderedAsFuture(t *testing.T) {
+	v := aged.New("R$ 49,99", now.Add(3*time.Hour))
+	if got := v.Age(now); got != 0 {
+		t.Fatalf("Age = %v, want 0 for a value stamped in the future", got)
+	}
+	if got := v.Classify(now, time.Minute); got != aged.FreshnessCurrent {
+		t.Fatalf("Classify = %v, want FreshnessCurrent", got)
+	}
+}
+
+// TestMapKeepsTheObservationTime guards the single way this mechanism is
+// defeated: transforming a value and re-stamping it as new, in code that looks
+// entirely reasonable.
+func TestMapKeepsTheObservationTime(t *testing.T) {
+	at := now.Add(-30 * 24 * time.Hour)
+	in := aged.New(4999, at)
+	out := aged.Map(in, func(cents int) string { return "R$ 49,99" })
+	if !out.At.Equal(at) {
+		t.Fatalf("Map re-stamped the value: %v, want %v", out.At, at)
+	}
+	if out.V != "R$ 49,99" {
+		t.Fatalf("Map lost the payload: %q", out.V)
+	}
+}

--- a/internal/arch/doc.go
+++ b/internal/arch/doc.go
@@ -1,0 +1,19 @@
+// Package arch holds no code. It holds the tests that keep the seam
+// architecture true over time.
+//
+// Three of Zerado's published promises are not properties of any one package —
+// they are properties of who imports whom:
+//
+//   - "Runs with the network off" holds because there is exactly one kind of
+//     package that may originate network I/O.
+//   - "No telemetry running in the background" is provable by inspection for
+//     the same reason.
+//   - "A screen never talks to a provider" holds because the import graph does
+//     not allow it.
+//
+// 07-offline-contract.md §7.3 proposes to keep the first two with a grep-level
+// rule in review. A rule nobody can check is a convention, and conventions
+// lose to deadlines — so the rules are executable here instead, and a change
+// that breaks one fails CI with the reason attached rather than being noticed
+// by whoever happened to review that afternoon.
+package arch

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -361,3 +361,41 @@ func TestEveryDocReferenceResolves(t *testing.T) {
 	}
 	t.Logf("%d doc references checked against %d files under docs/", checked, len(byName))
 }
+
+// TestTheGoDirectiveIsAResolvableToolchainVersion fails on a bare language
+// version in go.mod.
+//
+// `go 1.24` is a language version. Go cannot resolve a toolchain from it —
+// `GOTOOLCHAIN=go1.24 go env GOROOT` reports "go1.24 is a language version but
+// not a toolchain version" — and anything that resolves the pinned toolchain
+// before doing its job stops there. The review vehicle does exactly that, so
+// the module never reached the review at all: the failure was upstream of
+// every test in this package and invisible to all of them.
+//
+// It is the same shape as the defects this file already guards. A property the
+// project depends on (Sprint 0 #10: "go.mod declares the module and a pinned
+// Go toolchain version") held only because somebody typed the right thing, and
+// held nowhere that could notice when they did not.
+func TestTheGoDirectiveIsAResolvableToolchainVersion(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(moduleRoot(t), "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directive := regexp.MustCompile(`(?m)^go\s+(\S+)\s*$`)
+	m := directive.FindSubmatch(b)
+	if m == nil {
+		t.Fatal("go.mod has no go directive")
+	}
+	version := string(m[1])
+
+	// 1.X.Y — three components. Two is a language version and does not
+	// resolve; four is not a Go version at all.
+	full := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	if !full.MatchString(version) {
+		t.Fatalf("go.mod pins %q, which is a language version rather than a toolchain version.\n"+
+			"Go resolves a toolchain only from a full 1.X.Y, so anything that resolves the pin\n"+
+			"before running — the review vehicle, a reproducible build — fails before it reads\n"+
+			"a line of code. Sprint 0 #10 requires a pinned toolchain version.", version)
+	}
+}

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -231,8 +231,8 @@ func TestNoShippedCodeImportsAFake(t *testing.T) {
 // decided and all arrive with the implementation. It is an assertion about
 // *this* stage: the contracts are pure Go with a standard-library-only
 // dependency set, which is what lets every seam be exercised offline with no
-// module download and makes the go.sum in this pull request empty on purpose
-// rather than by omission.
+// module download and means this module has no go.sum at all — go.mod
+// declares no require, so there is nothing to lock.
 func TestTheModuleHasNoThirdPartyDependencies(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join(moduleRoot(t), "go.mod"))
 	if err != nil {

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -1,0 +1,244 @@
+package arch_test
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const module = "github.com/JustCode-CruzAlex/Zerado"
+
+// pkgImports maps each package's directory (relative to the module root) to
+// the set of paths its non-test files import.
+//
+// Test files are excluded deliberately: a test may import a fake, and a fake
+// may do things production code must not. What is being asserted here is what
+// ships.
+func pkgImports(t *testing.T) map[string][]string {
+	t.Helper()
+	root := moduleRoot(t)
+	out := map[string][]string{}
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || d.Name() == "site" || d.Name() == "docs" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if perr != nil {
+			return perr
+		}
+		rel, _ := filepath.Rel(root, filepath.Dir(path))
+		for _, imp := range f.Imports {
+			p, uerr := strconv.Unquote(imp.Path.Value)
+			if uerr != nil {
+				return uerr
+			}
+			out[rel] = append(out[rel], p)
+		}
+		if _, seen := out[rel]; !seen {
+			out[rel] = nil
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("no packages found; the walk is broken and every assertion below would pass vacuously")
+	}
+	return out
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the working directory")
+		}
+		dir = parent
+	}
+}
+
+// TestOnlyProvidersMayReachTheNetwork is 07-offline-contract.md §7.3's grep
+// rule, executable.
+//
+// It is the mechanism behind two published promises at once. A screen that
+// only reads local state works offline because it cannot do anything else, and
+// "the only network traffic is Zerado reaching out to the services you've
+// connected" is checkable rather than asserted — there is exactly one kind of
+// package where a packet can originate.
+func TestOnlyProvidersMayReachTheNetwork(t *testing.T) {
+	networking := []string{"net/http", "net/url", "net", "crypto/tls", "net/rpc"}
+	for pkg, imports := range pkgImports(t) {
+		if strings.HasPrefix(pkg, filepath.Join("internal", "provider")) {
+			continue // the one place a request may originate
+		}
+		for _, imp := range imports {
+			for _, n := range networking {
+				if imp == n {
+					t.Errorf("%s imports %q.\n"+
+						"Only provider packages may reach the network (07-offline-contract.md §7.3).\n"+
+						"If this is error classification rather than I/O, hand fault.Classify a\n"+
+						"fault.Transport verdict instead — that is exactly why it takes one.", pkg, imp)
+				}
+			}
+		}
+	}
+}
+
+// TestNoProviderConstructsItsOwnClient. 06-data-seams.md §7 declines to make
+// HTTP a seam and requires a shared client with a timeout, injected — because
+// a provider that builds its own is how a "works offline" claim quietly stops
+// being true, and how a request without a timeout hangs the sync screen
+// forever.
+//
+// The contracts stage of this ticket ships no provider that does I/O, so this
+// currently asserts a vacuous truth. It is here so that the first real
+// provider inherits the rule rather than discovering it in review.
+func TestNoProviderConstructsItsOwnClient(t *testing.T) {
+	root := moduleRoot(t)
+	dir := filepath.Join(root, "internal", "provider")
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		for _, bad := range []string{"http.Client{", "http.DefaultClient", "http.Transport{"} {
+			if strings.Contains(string(b), bad) {
+				rel, _ := filepath.Rel(root, path)
+				t.Errorf("%s constructs %s. The client is shared and injected, with a timeout "+
+					"(06-data-seams.md §7).", rel, bad)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the provider packages: %v", err)
+	}
+}
+
+// TestOnlyTheStoreKnowsThereIsADatabase. The persistence seam is the only
+// thing in the program that knows a database exists, and that is what makes it
+// the boundary the Phase 4 sync engine attaches to without touching a screen.
+func TestOnlyTheStoreKnowsThereIsADatabase(t *testing.T) {
+	dbish := []string{"database/sql", "modernc.org/sqlite", "github.com/mattn/go-sqlite3"}
+	for pkg, imports := range pkgImports(t) {
+		if strings.HasPrefix(pkg, filepath.Join("internal", "store")) {
+			continue
+		}
+		for _, imp := range imports {
+			for _, d := range dbish {
+				if imp == d {
+					t.Errorf("%s imports %q; every data access is behind the store interface", pkg, imp)
+				}
+			}
+		}
+	}
+}
+
+// TestAProviderNeverTalksToAScreenOrTheStore. 06-data-seams.md §1: a sync
+// writes to the store and the screens read from the store, and the two never
+// meet. If the provider seam could import the store, that rule would be a
+// habit rather than a structure.
+func TestAProviderNeverTalksToAScreenOrTheStore(t *testing.T) {
+	forbidden := map[string][]string{
+		filepath.Join("internal", "provider"): {
+			module + "/internal/store",
+			module + "/internal/library",
+		},
+		filepath.Join("internal", "library"): {
+			module + "/internal/store",
+		},
+	}
+	for pkg, bans := range forbidden {
+		for _, imp := range pkgImports(t)[pkg] {
+			for _, b := range bans {
+				if imp == b {
+					t.Errorf("%s imports %s; the seam only points one way", pkg, b)
+				}
+			}
+		}
+	}
+}
+
+// TestTheLeafPackagesStayLeaves. fault, i18n, status and aged are imported by
+// everything, so a dependency added to one of them is a dependency added to
+// the whole product — and a cycle in the seam graph is a refactor rather than
+// a fix.
+func TestTheLeafPackagesStayLeaves(t *testing.T) {
+	allowed := map[string]map[string]bool{
+		filepath.Join("internal", "i18n"):   {},
+		filepath.Join("internal", "status"): {},
+		filepath.Join("internal", "aged"):   {},
+		filepath.Join("internal", "fault"):  {module + "/internal/i18n": true},
+	}
+	for pkg, ok := range allowed {
+		for _, imp := range pkgImports(t)[pkg] {
+			if !strings.HasPrefix(imp, module) {
+				continue // the standard library is fine
+			}
+			if !ok[imp] {
+				t.Errorf("%s imports %s; it is a leaf and everything depends on it", pkg, imp)
+			}
+		}
+	}
+}
+
+// TestNoShippedCodeImportsAFake. A fake reaching production is how an
+// in-memory store ends up behind a real screen, and it is silent when it
+// happens.
+func TestNoShippedCodeImportsAFake(t *testing.T) {
+	for pkg, imports := range pkgImports(t) {
+		for _, imp := range imports {
+			if !strings.HasPrefix(imp, module) {
+				continue
+			}
+			base := imp[strings.LastIndex(imp, "/")+1:]
+			if strings.HasSuffix(base, "test") && base != "test" {
+				t.Errorf("%s imports the test double %s from non-test code", pkg, imp)
+			}
+		}
+	}
+}
+
+// TestTheModuleHasNoThirdPartyDependencies, for now.
+//
+// Not a permanent rule — Bubble Tea, x/text and a SQLite driver are all
+// decided and all arrive with the implementation. It is an assertion about
+// *this* stage: the contracts are pure Go with a standard-library-only
+// dependency set, which is what lets every seam be exercised offline with no
+// module download and makes the go.sum in this pull request empty on purpose
+// rather than by omission.
+func TestTheModuleHasNoThirdPartyDependencies(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(moduleRoot(t), "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "require") {
+		t.Skip("dependencies have arrived with the implementation; this stage-assertion has served its purpose")
+	}
+}

--- a/internal/arch/imports_test.go
+++ b/internal/arch/imports_test.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -225,20 +226,138 @@ func TestNoShippedCodeImportsAFake(t *testing.T) {
 	}
 }
 
-// TestTheModuleHasNoThirdPartyDependencies, for now.
+// TestEveryImportIsStandardLibraryOrLocal asserts what this stage of the
+// contracts actually promises: the module's dependency set is the Go standard
+// library and nothing else.
 //
-// Not a permanent rule — Bubble Tea, x/text and a SQLite driver are all
-// decided and all arrive with the implementation. It is an assertion about
-// *this* stage: the contracts are pure Go with a standard-library-only
-// dependency set, which is what lets every seam be exercised offline with no
-// module download and means this module has no go.sum at all — go.mod
-// declares no require, so there is nothing to lock.
-func TestTheModuleHasNoThirdPartyDependencies(t *testing.T) {
-	b, err := os.ReadFile(filepath.Join(moduleRoot(t), "go.mod"))
+// It replaces TestTheModuleHasNoThirdPartyDependencies, which could not fail.
+// That test read go.mod and either ended without asserting anything (no
+// require) or called t.Skip (require present) — there was no input for which
+// it reported a failure. A test that cannot fail is a green light nobody
+// earned, which is the same defect class as the hand-maintained fault.Kinds()
+// slice repaired in the previous round, and it was found the same way: by
+// somebody asking what would make it go red.
+//
+// This one has a real subject. It walks every non-test import in the module
+// and fails on any path that is neither module-local nor standard library.
+//
+// It is not a permanent rule. Bubble Tea, x/text and a SQLite driver are all
+// decided and all arrive with the implementation; at that point this test is
+// updated to an allow-list of the decided dependencies rather than deleted,
+// because "which third-party packages may this module import" stays a question
+// worth answering out loud.
+//
+// The stdlib test is the usual one: a standard-library path has no dot in its
+// first segment, because a dot there is a domain name. It is applied after the
+// module-local check, since the module path itself contains one.
+func TestEveryImportIsStandardLibraryOrLocal(t *testing.T) {
+	var checked int
+	for pkg, imports := range pkgImports(t) {
+		for _, imp := range imports {
+			checked++
+			if strings.HasPrefix(imp, module) {
+				continue
+			}
+			first, _, _ := strings.Cut(imp, "/")
+			if strings.Contains(first, ".") {
+				t.Errorf("%s imports %q, which is a third-party dependency.\n"+
+					"At this stage the contracts are standard-library-only: that is what lets\n"+
+					"every seam be exercised offline with no module download, and why this\n"+
+					"module has no go.sum. If the dependency is decided, add it to this test's\n"+
+					"allow-list so the set stays something somebody chose.", pkg, imp)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no imports were examined; the walk is broken and this assertion would pass vacuously")
+	}
+}
+
+// TestEveryDocReferenceResolves fails on a doc comment that cites a document
+// which does not exist.
+//
+// This is the third instance of the same defect in two review rounds: two
+// files cited a dossier document under a name it carried before it shipped,
+// and both were found by a human reading comments — the most expensive way to
+// find a broken link, and the one that stops happening the moment nobody has
+// time.
+//
+// It matters more here than in most codebases. This ticket's deliverable is
+// explicitly "the reasoning beside each signature", and that reasoning is
+// load-bearing precisely because it points at the ratified document a decision
+// came from. A citation that does not resolve is a decision whose provenance
+// has quietly been lost, in the one place the product keeps its provenance.
+//
+// Two citation styles are checked, because the comments use both: a full path
+// from the repository root, and the bare filename the blueprint and screen
+// specs are referred to by. The bare form resolves against a basename index of
+// docs/, which is looser than a path check and still catches the failure that
+// actually happens — a document renamed or never written.
+func TestEveryDocReferenceResolves(t *testing.T) {
+	root := moduleRoot(t)
+	docs := filepath.Join(root, "docs")
+
+	// A basename index of everything under docs/, for the bare-filename form.
+	byName := map[string]bool{}
+	if err := filepath.WalkDir(docs, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			byName[d.Name()] = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("indexing docs/: %v", err)
+	}
+	if len(byName) == 0 {
+		t.Fatal("docs/ indexed empty; every bare-filename assertion below would fail spuriously")
+	}
+
+	fullPath := regexp.MustCompile(`docs/[A-Za-z0-9._/-]+\.(?:md|toml|svg|json|css)`)
+	bareName := regexp.MustCompile(`\b(?:Z-\d{2}|\d{2})-[a-z0-9-]+\.md\b`)
+
+	var checked int
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || d.Name() == "site" || d.Name() == "docs" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		rel, _ := filepath.Rel(root, path)
+
+		for _, m := range fullPath.FindAllString(string(b), -1) {
+			checked++
+			if _, serr := os.Stat(filepath.Join(root, m)); serr != nil {
+				t.Errorf("%s cites %s, which does not exist.\n"+
+					"A citation that does not resolve is a decision whose provenance has been\n"+
+					"lost, in a deliverable whose value is that its reasoning is traceable.", rel, m)
+			}
+		}
+		for _, m := range bareName.FindAllString(string(b), -1) {
+			checked++
+			if !byName[m] {
+				t.Errorf("%s cites %s, and no file of that name exists under docs/.", rel, m)
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("walking the module: %v", err)
 	}
-	if strings.Contains(string(b), "require") {
-		t.Skip("dependencies have arrived with the implementation; this stage-assertion has served its purpose")
+	if checked == 0 {
+		t.Fatal("no doc references were examined; the patterns are broken and this would pass vacuously")
 	}
+	t.Logf("%d doc references checked against %d files under docs/", checked, len(byName))
 }

--- a/internal/audio/audio.go
+++ b/internal/audio/audio.go
@@ -1,0 +1,213 @@
+// Package audio is the sound seam: two channels, off by default, streamed
+// rather than bundled, and removable at runtime and at compile time.
+//
+// ADR-0001 D6 ships audio in Phase 1 as an opt-in subsystem whose music is
+// internet radio the player chooses, with local interface cues as the only
+// always-available part. Nothing ships in the binary, so there is nothing to
+// license, attribute or weigh — the most expensive open question in the audio
+// design was dissolved rather than answered.
+//
+// # The signatures carry the guarantees
+//
+// [Audio.Cue] has no error return and no context. That is not an oversight and
+// it is not minimalism: there is no audio failure a screen could usefully
+// handle, and an error return invites a caller to block on it. A cue that
+// cannot play is silence, and silence is not a failure a screen must render.
+//
+// [Audio.State] exists because Z-09 must say honestly *why* audio is
+// unavailable — a device that failed to open, an environment variable that
+// overrode it, a build without the subsystem in it. "Off" and "overridden" are
+// different facts and Settings shows which.
+//
+// # Audio is never the only carrier of information
+//
+// The co-render rule extended to a fourth channel. The test is
+// ZERADO_NO_AUDIO=1 and lose nothing — the same test NO_COLOR passes.
+//
+// # The build-tag split, and what this package does not decide
+//
+// The default build is pure Go and contains [Null], which keeps D2's
+// single-binary cross-compile property and means the silent path is exercised
+// by every test run rather than being an untested fallback. The real player
+// sits behind a build tag.
+//
+// 13-handoffs.md §4 assigns the choice of *which* audio library to this
+// ticket. It is not made here, and the reason is stated rather than skipped:
+// the requirement is a real per-platform check of each candidate's cgo
+// dependency, and that is a verification against six toolchains rather than a
+// signature decision. It changes no signature in this file — which is what the
+// build-tag seam was designed to guarantee — so it is recorded as still open
+// in docs/api/07-open-questions.md rather than answered from memory.
+package audio
+
+// Audio is the whole surface a screen sees.
+type Audio interface {
+	// Cue plays a short interface sound. It is fire-and-forget and it MUST
+	// NOT block.
+	//
+	// The implementation is a non-blocking send on a buffered channel: if the
+	// buffer is full the cue is dropped, silently, because a missed sound is
+	// not worth a dropped frame. A cue is always the second signal, never the
+	// first — the visible change happens on the frame it happens on, and the
+	// sound follows or does not.
+	Cue(c Cue)
+
+	// Music turns the radio stream on or off.
+	//
+	// Off releases the audio device AND closes the stream. It does not hold a
+	// gain of zero and it does not keep pulling bytes: a muted Zerado that
+	// kept taking a station's stream would be spending the player's bandwidth
+	// on silence, and it would sit badly against the published promise that
+	// the only network traffic is Zerado reaching out to services the player
+	// connected. Reconnecting on unmute costs a moment of buffering, which is
+	// the correct trade.
+	Music(on bool)
+
+	// SetVolume sets a channel's volume, 0..100. Out-of-range values are
+	// clamped rather than rejected: there is no failure here a screen could
+	// present.
+	SetVolume(ch Channel, v int)
+
+	// Mute mutes or unmutes one channel. The two channels are independent
+	// because someone may want keyclicks without the soundtrack, or the
+	// reverse, and neither is the odd request.
+	Mute(ch Channel, on bool)
+
+	// Muted reports a channel's mute state, for the footer indicator.
+	Muted(ch Channel) bool
+
+	// State is what Z-09 renders, including why audio is unavailable.
+	State() State
+
+	// Close stops the owned goroutine and releases the device.
+	//
+	// It has its own timeout: a stuck audio device does not stop q from
+	// quitting. The error is for logs; nothing waits on it.
+	Close() error
+}
+
+// Channel is one of the two independently controlled outputs.
+type Channel uint8
+
+const (
+	// ChannelMusic is the radio stream. It NEEDS THE NETWORK: offline it
+	// stops, and that is an honest degradation of a feature that is online by
+	// nature rather than a broken promise.
+	ChannelMusic Channel = iota
+
+	// ChannelFX is local interface cues. They WORK offline, because they are
+	// short, local, and reach for nothing.
+	ChannelFX
+)
+
+// String returns the stable machine name, used as a settings key suffix.
+func (c Channel) String() string {
+	if c == ChannelMusic {
+		return "music"
+	}
+	return "fx"
+}
+
+// Cue names an interface sound.
+//
+// It is an enum rather than a file path so that a screen names an *event* and
+// the audio implementation owns which sound an event makes — which is what
+// lets a theme change the sound set without a screen changing.
+type Cue uint8
+
+const (
+	// CueMove is a list cursor moving.
+	CueMove Cue = iota
+
+	// CueSelect is a choice being committed.
+	CueSelect
+
+	// CueZerado is the one cue that marks an achievement: a game becoming
+	// zerado. It is still never the only carrier — the chip changes colour,
+	// glyph and label on the same frame.
+	CueZerado
+
+	// CueSyncDone is a sync completing successfully. There is deliberately no
+	// cue for PARTIAL or CANCELLED: neither is a failure, and a sound would
+	// make them feel like one.
+	CueSyncDone
+
+	// CueSyncFailed is a sync failing.
+	CueSyncFailed
+
+	// CueRefuse is an action the product declined.
+	CueRefuse
+)
+
+// State is what Settings reports about audio, honestly.
+type State struct {
+	// Compiled reports whether this build contains the audio subsystem at
+	// all. False for the default pure-Go build.
+	Compiled bool
+
+	// Enabled is the player's own opt-in.
+	Enabled bool
+
+	// Available reports whether a device was successfully opened.
+	//
+	// Distinct from Enabled: a player can have turned audio on and have no
+	// device, which is a real state on a headless machine and one Settings
+	// must name rather than showing "On" over silence.
+	Available bool
+
+	// EnvOverride reports that ZERADO_NO_AUDIO is set.
+	//
+	// It is a separate field from Enabled because Z-09 must show "overridden",
+	// not "off" — those are different facts, and collapsing them would tell a
+	// player their setting had been changed when it had not.
+	EnvOverride bool
+
+	// ReasonKey names the catalogue entry explaining why audio is
+	// unavailable, when it is. Empty when it is available.
+	ReasonKey string
+
+	// DeviceKey names the catalogue entry describing the output — the
+	// "CoreAudio, built-in output" line. A key with arguments rather than a
+	// sentence, because the device name is a substitution and the phrasing
+	// around it is language.
+	DeviceKey string
+
+	// Volume and Muted are per channel, indexed by Channel.
+	Volume [2]int
+	Muted  [2]bool
+}
+
+// Null is the audio implementation that makes no sound.
+//
+// It is the DEFAULT build, not a fallback, which is the whole point of D6's
+// build-tag split: the silent path is exercised by every test run and every CI
+// job rather than being the untested branch that only fails on somebody's
+// laptop.
+type Null struct{}
+
+// Cue does nothing, immediately.
+func (Null) Cue(Cue) {}
+
+// Music does nothing.
+func (Null) Music(bool) {}
+
+// SetVolume does nothing.
+func (Null) SetVolume(Channel, int) {}
+
+// Mute does nothing.
+func (Null) Mute(Channel, bool) {}
+
+// Muted reports true for both channels: a build that makes no sound is
+// honestly muted, and the footer indicator says so rather than implying a
+// volume that does nothing.
+func (Null) Muted(Channel) bool { return true }
+
+// State reports a build with no audio in it, and names why.
+func (Null) State() State {
+	return State{Compiled: false, ReasonKey: "settings.audio.reason.not_compiled"}
+}
+
+// Close does nothing and cannot fail.
+func (Null) Close() error { return nil }
+
+var _ Audio = Null{}

--- a/internal/audio/audio_test.go
+++ b/internal/audio/audio_test.go
@@ -1,0 +1,66 @@
+package audio_test
+
+import (
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/audio"
+	"github.com/JustCode-CruzAlex/Zerado/internal/audio/audiotest"
+)
+
+// TestNullIsTheDefaultBuildAndIsHonestAboutIt. NullAudio is not a fallback
+// that might be untested; it is the default build, exercised by every test run
+// and every CI job — and Settings says "not compiled" rather than "off",
+// because those are different facts.
+func TestNullIsTheDefaultBuildAndIsHonestAboutIt(t *testing.T) {
+	var a audio.Audio = audio.Null{}
+	s := a.State()
+	if s.Compiled {
+		t.Fatal("the default build claims the audio subsystem is compiled in")
+	}
+	if s.ReasonKey == "" {
+		t.Fatal("Settings would show silence with no explanation")
+	}
+	if !a.Muted(audio.ChannelMusic) || !a.Muted(audio.ChannelFX) {
+		t.Fatal("a build that makes no sound reports itself unmuted; the footer indicator would imply a volume that does nothing")
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// TestCueCannotFail is the signature carrying the guarantee. There is no audio
+// failure a screen could usefully handle, and an error return invites a caller
+// to block on it.
+func TestCueCannotFail(t *testing.T) {
+	var cue func(audio.Cue) = audio.Null{}.Cue
+	for _, c := range []audio.Cue{audio.CueMove, audio.CueSelect, audio.CueZerado, audio.CueSyncDone, audio.CueSyncFailed, audio.CueRefuse} {
+		cue(c) // no error to check, and nothing to wait for
+	}
+}
+
+// TestNoCueForCancelledOrPartial: neither is a failure, and a sound would make
+// them feel like one. The cue set is the enumeration of that decision.
+func TestNoCueForCancelledOrPartial(t *testing.T) {
+	r := audiotest.New()
+	r.Cue(audio.CueSyncDone)
+	r.Cue(audio.CueSyncFailed)
+	if got := len(r.Cues()); got != 2 {
+		t.Fatalf("recorded %d cues, want 2", got)
+	}
+	// There is deliberately no CueSyncCancelled or CueSyncPartial to record.
+	// If one were added, this test's comment is where the argument against it
+	// lives.
+}
+
+// TestTheTwoChannelsAreIndependent: someone may want keyclicks without the
+// soundtrack, or the reverse, and neither is the odd request.
+func TestTheTwoChannelsAreIndependent(t *testing.T) {
+	r := audiotest.New()
+	r.Mute(audio.ChannelMusic, true)
+	if !r.Muted(audio.ChannelMusic) {
+		t.Fatal("muting music did not take")
+	}
+	if r.Muted(audio.ChannelFX) {
+		t.Fatal("muting music also muted the interface cues")
+	}
+}

--- a/internal/audio/audiotest/recorder.go
+++ b/internal/audio/audiotest/recorder.go
@@ -1,0 +1,76 @@
+// Package audiotest records what a screen asked for, so the co-render rule can
+// be tested: a cue may accompany a state change but must never be the only
+// carrier of it.
+package audiotest
+
+import (
+	"sync"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/audio"
+)
+
+// Recorder is an Audio that makes no sound and remembers everything.
+//
+// It never blocks, because the contract says Cue cannot — and a recorder that
+// took a lock a caller could contend on would be a test double that hid the
+// one property worth testing. The mutex here is held for the length of an
+// append and nothing else.
+type Recorder struct {
+	mu    sync.Mutex
+	cues  []audio.Cue
+	muted [2]bool
+	on    bool
+}
+
+// New returns an empty Recorder.
+func New() *Recorder { return &Recorder{} }
+
+// Cue records the cue and returns immediately.
+func (r *Recorder) Cue(c audio.Cue) {
+	r.mu.Lock()
+	r.cues = append(r.cues, c)
+	r.mu.Unlock()
+}
+
+// Music records the requested state.
+func (r *Recorder) Music(on bool) {
+	r.mu.Lock()
+	r.on = on
+	r.mu.Unlock()
+}
+
+// SetVolume does nothing.
+func (r *Recorder) SetVolume(audio.Channel, int) {}
+
+// Mute records the mute state.
+func (r *Recorder) Mute(ch audio.Channel, on bool) {
+	r.mu.Lock()
+	r.muted[ch] = on
+	r.mu.Unlock()
+}
+
+// Muted reports the recorded mute state.
+func (r *Recorder) Muted(ch audio.Channel) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.muted[ch]
+}
+
+// State reports a compiled, available, silent subsystem.
+func (r *Recorder) State() audio.State {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return audio.State{Compiled: true, Enabled: true, Available: true, Muted: r.muted}
+}
+
+// Close does nothing.
+func (r *Recorder) Close() error { return nil }
+
+// Cues returns everything cued so far.
+func (r *Recorder) Cues() []audio.Cue {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]audio.Cue(nil), r.cues...)
+}
+
+var _ audio.Audio = (*Recorder)(nil)

--- a/internal/cli/asfault.go
+++ b/internal/cli/asfault.go
@@ -1,0 +1,11 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+)
+
+// asFault is errors.As specialised to *fault.Fault, kept in its own file so
+// the envelope reads as a data shape rather than as error plumbing.
+func asFault(err error, target **fault.Fault) bool { return errors.As(err, target) }

--- a/internal/cli/envelope.go
+++ b/internal/cli/envelope.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+)
+
+// Envelope is the shape of every --json response.
+//
+// One shape for success and failure, because a caller that has to parse two
+// different top-level structures depending on an exit code is a caller that
+// will get it wrong on the day it matters. The discriminator is [Envelope.OK],
+// and exactly one of Data and Error is present.
+//
+// # The stability policy, stated so it can be held to
+//
+//   - [APIVersion] appears in every envelope and is the contract's major
+//     version.
+//   - Fields are added, never removed and never repurposed. A consumer that
+//     ignores unknown fields keeps working across every minor change.
+//   - A field's meaning is fixed. Changing what "unchanged" counts is a
+//     breaking change even though the JSON looks identical, and it bumps the
+//     version.
+//   - Error kinds are the fault taxonomy's stable names. Adding a kind is
+//     additive; a consumer that does not recognise one must treat it as a
+//     failure rather than as success, which is why [Envelope.OK] exists
+//     separately from the kind.
+//   - Exit codes and kinds move together and are documented together.
+type Envelope struct {
+	// API is the contract's major version. Always present.
+	API int `json:"api"`
+
+	// OK is the discriminator. A consumer branches on this, not on the
+	// presence of a key and not on the exit code, which it may not have.
+	OK bool `json:"ok"`
+
+	// Data is the verb's own payload, present only when OK.
+	Data any `json:"data,omitempty"`
+
+	// Error describes the failure, present only when not OK.
+	Error *ErrorBody `json:"error,omitempty"`
+}
+
+// ErrorBody is the machine-readable half of a failure.
+//
+// It carries no message. That is not an omission: a message is user-facing
+// text, it is rendered from the catalogue in the player's language, and a
+// pre-rendered English sentence in a JSON field is exactly the D9 violation
+// that is hardest to spot. A consumer that wants a sentence renders one from
+// the kind; a consumer that wants to branch uses the kind, which is what it
+// should have been using anyway.
+type ErrorBody struct {
+	// Kind is the taxonomy's stable machine name — "offline", "unauthorized".
+	Kind string `json:"kind"`
+
+	// Op names the operation, for a bug report.
+	Op string `json:"op,omitempty"`
+
+	// Subject is the provider's display name, when the failure was about one.
+	Subject string `json:"subject,omitempty"`
+
+	// MessageKey is the catalogue key that would render this, so a consumer
+	// with the catalogue can produce the same sentence Zerado would.
+	MessageKey string `json:"message_key,omitempty"`
+
+	// RetryAfterSeconds is the provider's own wait instruction, when it gave
+	// one. Seconds rather than a duration string, because every JSON consumer
+	// can compare a number and not all of them can parse "1m30s".
+	RetryAfterSeconds int `json:"retry_after_seconds,omitempty"`
+}
+
+// Ok builds a success envelope.
+func Ok(data any) Envelope { return Envelope{API: APIVersion, OK: true, Data: data} }
+
+// Err builds a failure envelope from any error.
+//
+// It never carries the wrapped cause. The cause may contain a URL with the
+// player's API key in its query string, and a JSON envelope is the single most
+// likely thing in this product to be piped into a file and attached to a bug
+// report.
+func Err(err error) Envelope {
+	k := fault.KindOf(err)
+	body := &ErrorBody{
+		Kind:       k.String(),
+		MessageKey: fault.MessageKeyOf(err).String(),
+		Subject:    fault.SubjectOf(err),
+	}
+	if d := fault.RetryAfterOf(err); d > 0 {
+		body.RetryAfterSeconds = int(d.Seconds())
+	}
+	var f *fault.Fault
+	if asFault(err, &f) {
+		body.Op = f.Op
+	}
+	return Envelope{API: APIVersion, OK: false, Error: body}
+}

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -65,9 +65,17 @@ const (
 
 // ExitCode maps an error to its process exit status.
 //
-// It is total over fault.Kinds(): every member of the taxonomy has a code,
-// asserted by a test rather than by inspection, so adding a Kind without
-// deciding what a script should do about it fails CI.
+// It is total over fault.Kinds(), which is derived from the taxonomy's iota
+// range rather than hand-listed — so a Kind added anywhere in that range is in
+// the set the totality tests iterate, and one that has not been given a code
+// here falls to ExitInternal and fails
+// TestNoKindSilentlyInheritsTheInternalExitCode.
+//
+// The earlier version of this comment claimed the same guarantee while
+// fault.Kinds() was a literal slice, which made it false for the most natural
+// way to add a Kind: inserting it mid-block. Corrected rather than quietly
+// fixed, because a comment asserting an enforcement that does not exist is
+// worse than no comment at all.
 //
 // A nil error is ExitOK. An unclassified error is ExitInternal, never a
 // plausible-looking network code — a scripted caller retrying forever because

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -1,0 +1,102 @@
+package cli
+
+import "github.com/JustCode-CruzAlex/Zerado/internal/fault"
+
+// Exit codes. These are API: a script branches on them, and a script cannot be
+// recompiled.
+//
+// The mapping is one-to-one with the fault taxonomy wherever a distinction is
+// actionable from a shell, and it deliberately does not collapse the four
+// network-ish failures into one. A cron job that syncs nightly wants to retry
+// on ExitOffline and alert on ExitUnauthorized, and it cannot do that if both
+// are 1.
+//
+// The numbers are small and contiguous rather than sysexits.h-style, with one
+// borrowed convention: [ExitCancelled] is 130, which is what a shell reports
+// for a process killed by SIGINT, so a player who pressed Ctrl-C sees the
+// number they would have seen anyway.
+const (
+	// ExitOK is success.
+	ExitOK = 0
+
+	// ExitInternal is a defect in Zerado.
+	ExitInternal = 1
+
+	// ExitUsage is a malformed invocation: an unknown verb, a missing
+	// required argument, --json on an interactive verb.
+	ExitUsage = 2
+
+	// ExitOffline is no route or no DNS.
+	ExitOffline = 3
+
+	// ExitUnreachable is a timeout or a 5xx.
+	ExitUnreachable = 4
+
+	// ExitUnauthorized is a rejected credential. Retrying will not help; the
+	// key has to change.
+	ExitUnauthorized = 5
+
+	// ExitEmpty is a successful request that returned nothing — the private
+	// profile. Distinct from ExitUnauthorized because the key is fine, and
+	// distinct from ExitOK because nothing was synced.
+	ExitEmpty = 6
+
+	// ExitRateLimited is the provider asking for a wait. A scripted caller
+	// may back off and retry; the wait, when the provider stated one, is in
+	// the JSON envelope.
+	ExitRateLimited = 7
+
+	// ExitNotFound is a named game, provider or setting that does not exist.
+	ExitNotFound = 8
+
+	// ExitMalformed is an answer Zerado could not read, or a value the player
+	// supplied that a provider would not accept.
+	ExitMalformed = 9
+
+	// ExitState is an operation that is legal but not possible right now: a
+	// precondition, a conflict, a capability the provider does not have, or a
+	// value too stale to act on. Grouped because a shell cannot usefully do
+	// anything different about them.
+	ExitState = 10
+
+	// ExitCancelled is the player stopping it. 130 by shell convention.
+	ExitCancelled = 130
+)
+
+// ExitCode maps an error to its process exit status.
+//
+// It is total over fault.Kinds(): every member of the taxonomy has a code,
+// asserted by a test rather than by inspection, so adding a Kind without
+// deciding what a script should do about it fails CI.
+//
+// A nil error is ExitOK. An unclassified error is ExitInternal, never a
+// plausible-looking network code — a scripted caller retrying forever because
+// an internal panic was reported as a timeout is a worse outcome than a loud
+// 1.
+func ExitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	switch fault.KindOf(err) {
+	case fault.KindOffline:
+		return ExitOffline
+	case fault.KindUnreachable:
+		return ExitUnreachable
+	case fault.KindUnauthorized:
+		return ExitUnauthorized
+	case fault.KindRateLimited:
+		return ExitRateLimited
+	case fault.KindEmpty:
+		return ExitEmpty
+	case fault.KindNotFound:
+		return ExitNotFound
+	case fault.KindMalformed:
+		return ExitMalformed
+	case fault.KindStale, fault.KindUnsupported, fault.KindPrecondition, fault.KindConflict:
+		return ExitState
+	case fault.KindCancelled:
+		return ExitCancelled
+	default:
+		return ExitInternal
+	}
+}

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -1,0 +1,262 @@
+// Package cli is the command-line surface treated as what it is: a public API
+// that gets designed, versioned and kept stable, rather than accreted.
+//
+// A CLI is an API the moment anyone types it. A verb name in somebody's shell
+// history, a script parsing an exit code, a cron line — each is a caller with
+// no upgrade path, and getting a verb name wrong is a breaking change later.
+// So the surface is declared here, in one table, with its exit codes and its
+// output shape, and the stability policy is written down before there is
+// anything to break.
+//
+// # What this package is and is not
+//
+// It is the surface: verbs, arguments, flags, exit codes, output envelope,
+// phase and stability. It contains no flag parsing, no command implementations
+// and no printing. The point is that the surface can be reviewed, diffed and
+// tested as data before any of it is built, and that a future command cannot
+// quietly acquire a verb that was never designed.
+package cli
+
+// APIVersion is the major version of the machine-readable output contract.
+//
+// It appears in every --json envelope. A script may branch on it. It is
+// incremented only for a breaking change to the envelope or to a documented
+// field's meaning; adding a field is not breaking and does not bump it.
+const APIVersion = 1
+
+// Phase is when a verb becomes real.
+//
+// It is on the surface rather than in a comment because of anti-pattern 14:
+// copy that mentions a capability the build does not have presents something
+// unbuilt as working. A reserved verb is listed in the documentation as
+// reserved and refuses with a clear message; it never half-works.
+type Phase uint8
+
+const (
+	// PhaseOne verbs ship in Phase 1.
+	PhaseOne Phase = iota
+
+	// PhaseLater verbs are reserved: the name is claimed so a Phase 1 user
+	// cannot squat it and so a future release does not have to pick a worse
+	// word. They are not routed and they are not advertised in help as
+	// available.
+	PhaseLater
+)
+
+// Stability is the promise attached to a verb.
+type Stability uint8
+
+const (
+	// StabilityStable means the verb, its arguments, its exit codes and its
+	// JSON fields will not change incompatibly within this major version.
+	StabilityStable Stability = iota
+
+	// StabilityReserved means the name is claimed and nothing else is
+	// promised.
+	StabilityReserved
+)
+
+// Verb is one top-level command.
+type Verb struct {
+	// Name is what the player types. It is the API.
+	Name string
+
+	// SummaryKey names the catalogue entry describing it in help. A key
+	// rather than a sentence: help text is user-facing, and D9 admits no
+	// literal even here.
+	SummaryKey string
+
+	// Args are the positional arguments, in order.
+	Args []Arg
+
+	// Flags are the options this verb accepts, on top of [GlobalFlags].
+	Flags []Flag
+
+	// Phase and Stability say whether this verb does anything yet and what is
+	// promised about it.
+	Phase     Phase
+	Stability Stability
+
+	// Interactive reports whether the verb hands control to the TUI rather
+	// than printing and exiting.
+	//
+	// It matters to the contract because an interactive verb cannot honour
+	// --json, and a caller piping one deserves a usage error rather than a
+	// terminal full of escape sequences.
+	Interactive bool
+
+	// NeedsNetwork records the verb's offline class, from
+	// 07-offline-contract.md's three-way split. It is here so the CLI's own
+	// help can state it and so a scripted caller can tell, before running
+	// anything, which verbs will refuse on a plane.
+	NeedsNetwork bool
+}
+
+// Arg is a positional argument.
+type Arg struct {
+	Name     string
+	Required bool
+
+	// Repeated means the argument may be given more than once and collects.
+	Repeated bool
+}
+
+// Flag is one option.
+type Flag struct {
+	// Name is the long form, without dashes. There are no single-letter
+	// aliases in Phase 1: a one-letter flag is the hardest thing to rename
+	// and the easiest to collide, and the TUI is where speed lives.
+	Name string
+
+	// SummaryKey names the catalogue entry describing it.
+	SummaryKey string
+
+	// Value is the placeholder shown in help, or empty for a boolean flag.
+	Value string
+}
+
+// GlobalFlags apply to every verb.
+//
+// They are global because each one is about how the program talks rather than
+// about what it does, and because a flag that means the same thing everywhere
+// should not have to be re-declared per verb — which is how it comes to mean
+// three slightly different things.
+func GlobalFlags() []Flag {
+	return []Flag{
+		{Name: "json", SummaryKey: "cli.flag.json"},
+		{Name: "quiet", SummaryKey: "cli.flag.quiet"},
+		{Name: "db", SummaryKey: "cli.flag.db", Value: "path"},
+		{Name: "no-color", SummaryKey: "cli.flag.no_color"},
+		{Name: "version", SummaryKey: "cli.flag.version"},
+		{Name: "help", SummaryKey: "cli.flag.help"},
+	}
+}
+
+// Surface returns every verb Zerado claims, in help order.
+//
+// The reserved entries are as much a part of the deliverable as the live ones:
+// they are the names Phase 2 and Phase 3 will need, claimed now, so that a
+// Phase 1 user's script cannot come to depend on `zerado tonight` meaning
+// something else and so that the eventual feature does not have to settle for
+// a worse word.
+func Surface() []Verb {
+	return []Verb{
+		{
+			// The bare command is the product. Everything else is a
+			// convenience for people who are not in it.
+			Name:        "",
+			SummaryKey:  "cli.verb.tui",
+			Phase:       PhaseOne,
+			Stability:   StabilityStable,
+			Interactive: true,
+		},
+		{
+			Name:       "sync",
+			SummaryKey: "cli.verb.sync",
+			Args:       []Arg{{Name: "provider"}},
+			Flags: []Flag{
+				{Name: "all", SummaryKey: "cli.flag.sync.all"},
+			},
+			Phase:        PhaseOne,
+			Stability:    StabilityStable,
+			NeedsNetwork: true,
+		},
+		{
+			Name:       "list",
+			SummaryKey: "cli.verb.list",
+			Flags: []Flag{
+				{Name: "state", SummaryKey: "cli.flag.list.state", Value: "state"},
+				{Name: "source", SummaryKey: "cli.flag.list.source", Value: "provider"},
+				{Name: "search", SummaryKey: "cli.flag.list.search", Value: "text"},
+				{Name: "absent", SummaryKey: "cli.flag.list.absent"},
+				{Name: "limit", SummaryKey: "cli.flag.list.limit", Value: "n"},
+			},
+			Phase:     PhaseOne,
+			Stability: StabilityStable,
+		},
+		{
+			Name:       "mark",
+			SummaryKey: "cli.verb.mark",
+			Args: []Arg{
+				{Name: "game", Required: true},
+				{Name: "state", Required: true},
+			},
+			Flags: []Flag{
+				// Clearing an override is a different action from setting
+				// NOT STARTED, and the CLI has to be able to express both or
+				// it cannot do what Z-06 does.
+				{Name: "clear", SummaryKey: "cli.flag.mark.clear"},
+			},
+			Phase:     PhaseOne,
+			Stability: StabilityStable,
+		},
+		{
+			Name:       "add",
+			SummaryKey: "cli.verb.add",
+			Flags: []Flag{
+				{Name: "title", SummaryKey: "cli.flag.add.title", Value: "text"},
+				{Name: "platform", SummaryKey: "cli.flag.add.platform", Value: "text"},
+				{Name: "state", SummaryKey: "cli.flag.add.state", Value: "state"},
+				{Name: "owned-since", SummaryKey: "cli.flag.add.owned_since", Value: "date"},
+			},
+			Phase:     PhaseOne,
+			Stability: StabilityStable,
+		},
+		{
+			// The deep link. 04-navigation-and-focus.md §288 notes that this
+			// requires the route stack to be constructible from a descriptor
+			// rather than only by pushing — which is a Phase 1 constraint that
+			// exists because of this verb, and is recorded here so the cost is
+			// attached to the thing that causes it.
+			Name:        "game",
+			SummaryKey:  "cli.verb.game",
+			Args:        []Arg{{Name: "game", Required: true}},
+			Phase:       PhaseOne,
+			Stability:   StabilityStable,
+			Interactive: true,
+		},
+		{
+			// Everything Z-09 reports, for someone who cannot open a TUI —
+			// the database path, the vault backing, the image capability, the
+			// audio state. It reaches no network, which is what makes it a
+			// diagnostic rather than a connectivity test.
+			Name:       "doctor",
+			SummaryKey: "cli.verb.doctor",
+			Phase:      PhaseOne,
+			Stability:  StabilityStable,
+		},
+		{
+			Name:       "version",
+			SummaryKey: "cli.verb.version",
+			Phase:      PhaseOne,
+			Stability:  StabilityStable,
+		},
+		{
+			Name:       "help",
+			SummaryKey: "cli.verb.help",
+			Args:       []Arg{{Name: "verb"}},
+			Phase:      PhaseOne,
+			Stability:  StabilityStable,
+		},
+
+		// ---- Reserved. Claimed, not routed, never half-working. ----
+		{Name: "tonight", SummaryKey: "cli.verb.tonight", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "price", SummaryKey: "cli.verb.price", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "watch", SummaryKey: "cli.verb.watch", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "tag", SummaryKey: "cli.verb.tag", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "enrich", SummaryKey: "cli.verb.enrich", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "devices", SummaryKey: "cli.verb.devices", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "export", SummaryKey: "cli.verb.export", Phase: PhaseLater, Stability: StabilityReserved},
+		{Name: "import", SummaryKey: "cli.verb.import", Phase: PhaseLater, Stability: StabilityReserved},
+	}
+}
+
+// Lookup returns the verb with this name.
+func Lookup(name string) (Verb, bool) {
+	for _, v := range Surface() {
+		if v.Name == name {
+			return v, true
+		}
+	}
+	return Verb{}, false
+}

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -94,8 +94,27 @@ type Verb struct {
 
 // Arg is a positional argument.
 type Arg struct {
-	Name     string
+	Name string
+
+	// Required means the verb refuses without it — unless one of
+	// [Arg.RequiredUnless] is present.
 	Required bool
+
+	// RequiredUnless names flags whose presence makes this argument optional.
+	//
+	// It exists because the surface has to be able to express `mark --clear`,
+	// and an earlier revision could not: `state` was flatly Required and
+	// `--clear` was declared alongside it, so a parser reading this surface as
+	// data would reject `zerado mark <game> --clear` for a missing argument —
+	// while the dossier says plainly that a CLI without --clear could not do
+	// what Z-06 does.
+	//
+	// A surface that contradicts its own stated requirement is worse than an
+	// incomplete one, because the contradiction is only discovered by whoever
+	// writes the parser. [Verb.MissingArgs] resolves it, and
+	// TestTheSurfaceCanExpressEveryDocumentedInvocation asserts the surface
+	// admits each invocation the dossier promises.
+	RequiredUnless []string
 
 	// Repeated means the argument may be given more than once and collects.
 	Repeated bool
@@ -179,12 +198,14 @@ func Surface() []Verb {
 			SummaryKey: "cli.verb.mark",
 			Args: []Arg{
 				{Name: "game", Required: true},
-				{Name: "state", Required: true},
+				{Name: "state", Required: true, RequiredUnless: []string{"clear"}},
 			},
 			Flags: []Flag{
 				// Clearing an override is a different action from setting
 				// NOT STARTED, and the CLI has to be able to express both or
-				// it cannot do what Z-06 does.
+				// it cannot do what Z-06 does. That is why `state` above is
+				// required *unless* this flag is present rather than flatly
+				// required.
 				{Name: "clear", SummaryKey: "cli.flag.mark.clear"},
 			},
 			Phase:     PhaseOne,
@@ -249,6 +270,41 @@ func Surface() []Verb {
 		{Name: "export", SummaryKey: "cli.verb.export", Phase: PhaseLater, Stability: StabilityReserved},
 		{Name: "import", SummaryKey: "cli.verb.import", Phase: PhaseLater, Stability: StabilityReserved},
 	}
+}
+
+// MissingArgs returns the names of this verb's required positional arguments
+// that were not supplied, given the flags that were.
+//
+// given is the set of positional arguments actually present, in order, and
+// flags is the set of flag names supplied. It is the one piece of behaviour on
+// this surface, and it is here rather than in a future parser because the
+// surface's own claim — that it can express every documented invocation — is
+// otherwise unfalsifiable.
+func (v Verb) MissingArgs(given []string, flags map[string]bool) []string {
+	var missing []string
+	for i, a := range v.Args {
+		if i < len(given) && given[i] != "" {
+			continue
+		}
+		if !a.Required {
+			continue
+		}
+		if satisfiedBy(a.RequiredUnless, flags) {
+			continue
+		}
+		missing = append(missing, a.Name)
+	}
+	return missing
+}
+
+// satisfiedBy reports whether any of names is present in flags.
+func satisfiedBy(names []string, flags map[string]bool) bool {
+	for _, n := range names {
+		if flags[n] {
+			return true
+		}
+	}
+	return false
 }
 
 // Lookup returns the verb with this name.

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -242,3 +242,98 @@ func TestNoKindSilentlyInheritsTheInternalExitCode(t *testing.T) {
 		}
 	}
 }
+
+// TestTheSurfaceCanExpressEveryDocumentedInvocation is the MINOR-2 repair from
+// the review at 4484d9a.
+//
+// The surface is this ticket's deliverable, as reviewable data. It contained a
+// contradiction: `mark` declared both a required `state` argument and a
+// `--clear` flag, so a parser reading it would reject `zerado mark <game>
+// --clear` — while docs/api/03-cli-surface.md says a CLI without --clear could
+// not do what Z-06 does.
+//
+// TestVerbSurfaceIsStable pins verb names and nothing else, which is why the
+// contradiction survived. This pins the arities against the invocations the
+// dossier actually promises, so the surface and its documentation cannot drift
+// apart without one of them failing.
+func TestTheSurfaceCanExpressEveryDocumentedInvocation(t *testing.T) {
+	cases := []struct {
+		verb    string
+		args    []string
+		flags   []string
+		accept  bool
+		because string
+	}{
+		{verb: "mark", args: []string{"42", "zerado"}, accept: true,
+			because: "setting a state is the ordinary invocation"},
+		{verb: "mark", args: []string{"42"}, flags: []string{"clear"}, accept: true,
+			because: "clearing an override is a different action from setting NOT STARTED (03-cli-surface.md §1)"},
+		{verb: "mark", args: []string{"42"}, accept: false,
+			because: "without --clear, a state is required"},
+		{verb: "mark", args: nil, flags: []string{"clear"}, accept: false,
+			because: "--clear still needs to know which game"},
+		{verb: "sync", args: nil, accept: true,
+			because: "the provider argument is optional; --all or a default covers it"},
+		{verb: "sync", args: []string{"steam"}, accept: true},
+		{verb: "game", args: nil, accept: false,
+			because: "the deep link needs a game"},
+		{verb: "game", args: []string{"42"}, accept: true},
+		{verb: "list", args: nil, accept: true},
+		{verb: "help", args: nil, accept: true,
+			because: "bare help lists the verbs"},
+		{verb: "help", args: []string{"sync"}, accept: true},
+	}
+
+	for _, c := range cases {
+		v, ok := cli.Lookup(c.verb)
+		if !ok {
+			t.Fatalf("verb %q is not on the surface", c.verb)
+		}
+		flags := map[string]bool{}
+		for _, f := range c.flags {
+			flags[f] = true
+		}
+		missing := v.MissingArgs(c.args, flags)
+		accepted := len(missing) == 0
+
+		if accepted != c.accept {
+			verdict := "rejected"
+			if accepted {
+				verdict = "accepted"
+			}
+			t.Errorf("zerado %s %v %v was %s (missing %v), want accept=%v%s",
+				c.verb, c.args, c.flags, verdict, missing, c.accept, reason(c.because))
+		}
+	}
+}
+
+func reason(s string) string {
+	if s == "" {
+		return ""
+	}
+	return " — " + s
+}
+
+// TestEveryRequiredUnlessNamesARealFlag: a guard that resolves against a flag
+// the verb does not declare would silently never be satisfied, turning an
+// optional-under-a-flag argument back into a flatly required one.
+func TestEveryRequiredUnlessNamesARealFlag(t *testing.T) {
+	global := map[string]bool{}
+	for _, f := range cli.GlobalFlags() {
+		global[f.Name] = true
+	}
+	for _, v := range cli.Surface() {
+		declared := map[string]bool{}
+		for _, f := range v.Flags {
+			declared[f.Name] = true
+		}
+		for _, a := range v.Args {
+			for _, name := range a.RequiredUnless {
+				if !declared[name] && !global[name] {
+					t.Errorf("verb %q: argument %q is required unless --%s, which the verb does not declare",
+						v.Name, a.Name, name)
+				}
+			}
+		}
+	}
+}

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -225,3 +225,20 @@ func contains(hay, needle string) bool {
 	}
 	return false
 }
+
+// TestNoKindSilentlyInheritsTheInternalExitCode is the CLI half of the
+// taxonomy-totality repair.
+//
+// ExitCode's default is ExitInternal, so a Kind nobody gave a code to still
+// exits 1 — which is a plausible-looking answer and therefore the dangerous
+// one. Only KindInternal is entitled to it.
+func TestNoKindSilentlyInheritsTheInternalExitCode(t *testing.T) {
+	for _, k := range fault.Kinds() {
+		if k == fault.KindInternal {
+			continue
+		}
+		if got := cli.ExitCode(fault.New(k, "test.Op")); got == cli.ExitInternal {
+			t.Errorf("kind %v exits %d; it has no case in ExitCode and a script would read it as our defect", k, got)
+		}
+	}
+}

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -1,0 +1,227 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/cli"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+)
+
+// TestExitCodesAreTotal fails the moment a Kind is added without deciding what
+// a script should do about it. A taxonomy the CLI cannot express is a taxonomy
+// that reaches a shell as 1.
+func TestExitCodesAreTotal(t *testing.T) {
+	for _, k := range fault.Kinds() {
+		err := fault.New(k, "test.Op")
+		code := cli.ExitCode(err)
+		if code == cli.ExitOK {
+			t.Errorf("%v maps to exit 0; a failure reported as success is the worst outcome for a scripted caller", k)
+		}
+		if code < 0 || code > 255 {
+			t.Errorf("%v maps to %d, which is not a valid process exit status", k, code)
+		}
+	}
+	if got := cli.ExitCode(nil); got != cli.ExitOK {
+		t.Fatalf("ExitCode(nil) = %d", got)
+	}
+}
+
+// TestTheFourNetworkFailuresDoNotCollapse: a cron job wants to retry on
+// offline and alert on a rejected key, and it cannot do that if both are 1.
+func TestTheFourNetworkFailuresDoNotCollapse(t *testing.T) {
+	codes := map[int]fault.Kind{}
+	for _, k := range []fault.Kind{fault.KindOffline, fault.KindUnreachable, fault.KindUnauthorized, fault.KindEmpty, fault.KindRateLimited} {
+		c := cli.ExitCode(fault.New(k, "steam.Sync"))
+		if prev, dup := codes[c]; dup {
+			t.Fatalf("%v and %v both exit %d; a script cannot tell them apart", prev, k, c)
+		}
+		codes[c] = k
+	}
+}
+
+// TestCancelledUsesTheShellConvention: a player who pressed Ctrl-C sees the
+// number they would have seen anyway.
+func TestCancelledUsesTheShellConvention(t *testing.T) {
+	if got := cli.ExitCode(fault.New(fault.KindCancelled, "steam.Sync")); got != 130 {
+		t.Fatalf("cancelled exits %d, want 130", got)
+	}
+}
+
+// TestUnclassifiedIsNotANetworkCode: a scripted caller retrying forever
+// because an internal defect was reported as a timeout is worse than a loud 1.
+func TestUnclassifiedIsNotANetworkCode(t *testing.T) {
+	if got := cli.ExitCode(errString("boom")); got != cli.ExitInternal {
+		t.Fatalf("an unclassified error exits %d, want %d", got, cli.ExitInternal)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// TestVerbSurfaceIsStable is a golden list. A verb name in somebody's shell
+// history has no upgrade path, so renaming one has to be a deliberate act that
+// updates this test and says why in the diff.
+func TestVerbSurfaceIsStable(t *testing.T) {
+	want := []string{
+		"", "sync", "list", "mark", "add", "game", "doctor", "version", "help",
+		"tonight", "price", "watch", "tag", "enrich", "devices", "export", "import",
+	}
+	got := make([]string, 0, len(want))
+	for _, v := range cli.Surface() {
+		got = append(got, v.Name)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("the verb surface has %d entries, the golden list has %d:\n got %v\nwant %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("verb %d is %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestNoDuplicateVerbsAndNoDuplicateFlags.
+func TestNoDuplicateVerbsAndNoDuplicateFlags(t *testing.T) {
+	seen := map[string]bool{}
+	for _, v := range cli.Surface() {
+		if seen[v.Name] {
+			t.Fatalf("duplicate verb %q", v.Name)
+		}
+		seen[v.Name] = true
+
+		flags := map[string]bool{}
+		for _, f := range append(cli.GlobalFlags(), v.Flags...) {
+			if flags[f.Name] {
+				t.Fatalf("verb %q declares --%s twice, or shadows a global flag", v.Name, f.Name)
+			}
+			flags[f.Name] = true
+		}
+	}
+}
+
+// TestReservedVerbsPromiseNothing guards anti-pattern 14: a name is claimed so
+// a future feature does not have to settle for a worse word, and nothing about
+// it is advertised as working.
+func TestReservedVerbsPromiseNothing(t *testing.T) {
+	for _, v := range cli.Surface() {
+		if v.Phase != cli.PhaseLater {
+			continue
+		}
+		if v.Stability != cli.StabilityReserved {
+			t.Errorf("%q is reserved but promises stability", v.Name)
+		}
+		if len(v.Args) > 0 || len(v.Flags) > 0 {
+			t.Errorf("%q is reserved but declares arguments; a reserved verb has no shape yet", v.Name)
+		}
+	}
+	if v, ok := cli.Lookup("tonight"); !ok || v.Phase != cli.PhaseLater {
+		t.Fatal("tonight must be reserved: it is Phase 2 and its name must not be squatted")
+	}
+}
+
+// TestEveryVerbHasACatalogueKey: help text is user-facing, and D9 admits no
+// literal even there.
+func TestEveryVerbHasACatalogueKey(t *testing.T) {
+	for _, v := range cli.Surface() {
+		if v.SummaryKey == "" {
+			t.Errorf("verb %q has no summary key", v.Name)
+		}
+		for _, f := range v.Flags {
+			if f.SummaryKey == "" {
+				t.Errorf("verb %q flag --%s has no summary key", v.Name, f.Name)
+			}
+		}
+	}
+	for _, f := range cli.GlobalFlags() {
+		if f.SummaryKey == "" {
+			t.Errorf("global flag --%s has no summary key", f.Name)
+		}
+	}
+}
+
+// TestOfflineClassIsDeclared: a scripted caller can tell, before running
+// anything, which verbs refuse on a plane. Only the two verbs that are
+// definitionally about reaching somewhere else may claim it.
+func TestOfflineClassIsDeclared(t *testing.T) {
+	for _, v := range cli.Surface() {
+		if v.NeedsNetwork && v.Name != "sync" {
+			t.Errorf("verb %q claims it needs the network; every Phase 1 verb but sync reads local state", v.Name)
+		}
+	}
+	if v, _ := cli.Lookup("list"); v.NeedsNetwork {
+		t.Fatal("list needs the network; it is a WHERE clause")
+	}
+}
+
+// TestTheEnvelopeCarriesNoMessage. A pre-rendered English sentence in a JSON
+// field is the hardest D9 violation to spot, and a JSON envelope is the single
+// most likely thing in this product to be piped into a bug report.
+func TestTheEnvelopeCarriesNoMessage(t *testing.T) {
+	leak := errString(`Get "https://api.steampowered.com/x?key=SECRET-KEY-9F2": no route`)
+	f := fault.New(fault.KindOffline, "steam.Sync",
+		fault.WithSubject("Steam"), fault.WithCause(leak))
+
+	b, err := json.Marshal(cli.Err(f))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, forbidden := range []string{"SECRET-KEY-9F2", "api.steampowered.com", "no route"} {
+		if contains(s, forbidden) {
+			t.Fatalf("the JSON envelope leaked %q: %s", forbidden, s)
+		}
+	}
+
+	var env cli.Envelope
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.API != cli.APIVersion {
+		t.Fatalf("API = %d, want %d", env.API, cli.APIVersion)
+	}
+	if env.OK {
+		t.Fatal("a failure envelope reports ok")
+	}
+	if env.Error == nil || env.Error.Kind != "offline" {
+		t.Fatalf("Error = %+v", env.Error)
+	}
+	if env.Error.MessageKey == "" {
+		t.Fatal("no catalogue key; a consumer with the catalogue could not render the same sentence Zerado would")
+	}
+}
+
+// TestRetryAfterReachesTheEnvelopeAsSeconds: every JSON consumer can compare a
+// number and not all of them can parse "1m30s".
+func TestRetryAfterReachesTheEnvelopeAsSeconds(t *testing.T) {
+	f := fault.New(fault.KindRateLimited, "steam.Sync", fault.WithRetryAfter(90*time.Second))
+	env := cli.Err(f)
+	if env.Error.RetryAfterSeconds != 90 {
+		t.Fatalf("RetryAfterSeconds = %d, want 90", env.Error.RetryAfterSeconds)
+	}
+}
+
+// TestSuccessAndFailureShareOneShape: a caller that has to parse two different
+// top-level structures depending on an exit code will get it wrong on the day
+// it matters.
+func TestSuccessAndFailureShareOneShape(t *testing.T) {
+	ok := cli.Ok(map[string]int{"games": 247})
+	if !ok.OK || ok.Error != nil || ok.API != cli.APIVersion {
+		t.Fatalf("success envelope = %+v", ok)
+	}
+	bad := cli.Err(fault.New(fault.KindNotFound, "store.Game"))
+	if bad.OK || bad.Data != nil {
+		t.Fatalf("failure envelope = %+v", bad)
+	}
+}
+
+func contains(hay, needle string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/devicesync/payload_test.go
+++ b/internal/devicesync/payload_test.go
@@ -104,3 +104,48 @@ func TestTheMergeKeyIsTheCrossDeviceIdentity(t *testing.T) {
 		t.Fatalf("Change.UID is a %s; a merge keyed on a local id would match the wrong rows", got)
 	}
 }
+
+// TestPayloadTypesStayFlat closes the gap the review at c4c8d95 named: the
+// two guards above walk depth 1, because reflect.NumField does not descend.
+//
+// A future field whose type is a nested struct would pass both — the
+// allow-list sees only the outer name and the credential-name ban sees only
+// the outer name — while carrying anything at all inside it. That is not a
+// hypothetical shape for a sync payload: a `Device DeviceInfo` or a
+// `Source ProviderRef` is exactly what somebody adds in good faith.
+//
+// So rather than note the limitation, this pins the *types* as well as the
+// names. Every field of every payload struct must be one of a small allow-list
+// of leaf types, which makes nesting impossible without editing this test —
+// and editing this test is the moment somebody reads D4.
+func TestPayloadTypesStayFlat(t *testing.T) {
+	allowed := map[string]bool{
+		"string":                  true,
+		"devicesync.DeviceID":     true,
+		"library.UID":             true,
+		"time.Time":               true,
+		"*time.Time":              true,
+		"*status.Status":          true,
+		"[]devicesync.Change":     true,
+		"[]devicesync.ManualGame": true,
+		"int":                     true,
+	}
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(devicesync.Change{}),
+		reflect.TypeOf(devicesync.ManualGame{}),
+		reflect.TypeOf(devicesync.Envelope{}),
+		reflect.TypeOf(devicesync.Receipt{}),
+	} {
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !allowed[f.Type.String()] {
+				t.Errorf("%s.%s is a %s, which is not an allowed payload type.\n"+
+					"The allow-list is leaf types only, so that a nested struct cannot smuggle\n"+
+					"fields past the depth-1 checks above. If this type is genuinely something\n"+
+					"the player typed, add it here — and read ADR-0001 D4 while you are in this\n"+
+					"file, because that is what editing this list is for.",
+					typ.Name(), f.Name, f.Type)
+			}
+		}
+	}
+}

--- a/internal/devicesync/payload_test.go
+++ b/internal/devicesync/payload_test.go
@@ -1,0 +1,106 @@
+package devicesync_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/devicesync"
+)
+
+// TestPayloadCarriesOnlyWhatThePlayerTyped is the point of this package.
+//
+// ADR-0001 D4 decides what crosses the Phase 4 boundary, and it is the most
+// expensive decision in the bundle to reverse because it decides what the
+// schema carries from the first migration onward. A paragraph stating that
+// rule is a paragraph somebody will not have read in 2027, when adding
+// playtime to the payload will look like an obvious improvement — the server
+// already has the rows, and showing hours on another device is a nice feature.
+//
+// So the rule is a test. A field added to the payload fails here, by name,
+// with the decision attached.
+func TestPayloadCarriesOnlyWhatThePlayerTyped(t *testing.T) {
+	allowed := map[reflect.Type]map[string]bool{
+		reflect.TypeOf(devicesync.Change{}): {
+			"UID":       true, // the cross-device merge hint
+			"Status":    true, // the manual value, or nil for a clear
+			"ChangedAt": true, // decides the conflict
+		},
+		reflect.TypeOf(devicesync.ManualGame{}): {
+			"UID":        true,
+			"Title":      true, // the player typed it
+			"Platform":   true, // the player typed it
+			"CreatedAt":  true,
+			"OwnedSince": true, // the one optional thing the player typed
+		},
+		reflect.TypeOf(devicesync.Envelope{}): {
+			"Device":  true,
+			"Since":   true,
+			"Changes": true,
+			"Manual":  true,
+		},
+	}
+
+	for typ, ok := range allowed {
+		for i := 0; i < typ.NumField(); i++ {
+			name := typ.Field(i).Name
+			if !ok[name] {
+				t.Errorf("%s.%s crosses the Phase 4 sync boundary and is not on the allow-list.\n"+
+					"ADR-0001 D4: only what the player typed crosses. Everything a machine can\n"+
+					"recompute, each device recomputes. If this field is genuinely something the\n"+
+					"player typed, add it to the allow-list in this test with a reason. If it is a\n"+
+					"provider fact — playtime, last-played, a cover, a price — it must not cross.",
+					typ.Name(), name)
+			}
+		}
+	}
+}
+
+// TestNothingResemblingACredentialCanCross is the same guard aimed at the one
+// class of field that would be a breach rather than a design regression. A
+// ratified promise says the keys are the player's own; centralising them makes
+// Zerado a credential custodian, which is a different company.
+func TestNothingResemblingACredentialCanCross(t *testing.T) {
+	banned := []string{"key", "token", "secret", "password", "credential", "auth", "cookie", "session"}
+	types := []reflect.Type{
+		reflect.TypeOf(devicesync.Change{}),
+		reflect.TypeOf(devicesync.ManualGame{}),
+		reflect.TypeOf(devicesync.Envelope{}),
+		reflect.TypeOf(devicesync.Receipt{}),
+	}
+	for _, typ := range types {
+		for i := 0; i < typ.NumField(); i++ {
+			name := strings.ToLower(typ.Field(i).Name)
+			for _, b := range banned {
+				if strings.Contains(name, b) {
+					t.Fatalf("%s.%s looks like a credential. Credentials never cross the Phase 4 "+
+						"boundary — each device connects with its own keys (ADR-0001 D4).",
+						typ.Name(), typ.Field(i).Name)
+				}
+			}
+		}
+	}
+}
+
+// TestAClearedOverrideCanCross: "I have no opinion" is a change the player
+// made, so Status is a pointer and nil is meaningful. A non-nullable field
+// would make a clear unsyncable, and the player's device would silently
+// disagree with itself forever.
+func TestAClearedOverrideCanCross(t *testing.T) {
+	f, ok := reflect.TypeOf(devicesync.Change{}).FieldByName("Status")
+	if !ok {
+		t.Fatal("Change has no Status field")
+	}
+	if f.Type.Kind() != reflect.Pointer {
+		t.Fatalf("Change.Status is %v; it must be nullable so that clearing an override can cross", f.Type.Kind())
+	}
+}
+
+// TestTheMergeKeyIsTheCrossDeviceIdentity: a local surrogate key means nothing
+// on another machine, which is exactly why library.UID exists in Phase 1.
+func TestTheMergeKeyIsTheCrossDeviceIdentity(t *testing.T) {
+	f, _ := reflect.TypeOf(devicesync.Change{}).FieldByName("UID")
+	if got := f.Type.Name(); got != "UID" {
+		t.Fatalf("Change.UID is a %s; a merge keyed on a local id would match the wrong rows", got)
+	}
+}

--- a/internal/devicesync/sketch.go
+++ b/internal/devicesync/sketch.go
@@ -1,0 +1,153 @@
+// Package devicesync sketches the Phase 4 client/server boundary.
+//
+// # This is a sketch and it builds nothing
+//
+// No Phase 1 code calls it. It exists because ADR-0001 D4 decides *what
+// crosses* the boundary now rather than in Phase 4, and because that decision
+// is the most expensive one in the bundle to reverse: it decides what the
+// schema carries from the first migration onward. A sketch that compiles is a
+// decision that can be checked; a paragraph is a decision that can be
+// misremembered.
+//
+// # The rule, in one line
+//
+// Only what the player typed crosses. Everything a machine can recompute,
+// each device recomputes.
+//
+//	Crosses:        the manual status and when it changed; hand-entered games;
+//	                a stable identity; mood tags the player assigned (Phase 2).
+//	Never crosses:  the library itself; playtime; last-played; cover art;
+//	                sinopse; prices; credentials, ever.
+//
+// # The rule is enforced, not merely documented
+//
+// [Change] and [ManualGame] have no field that could carry a provider fact or
+// a credential, and TestPayloadCarriesOnlyWhatThePlayerTyped walks their field
+// sets against an allow-list. A future contributor adding PlaytimeMinutes to
+// the payload — for entirely reasonable-looking reasons, in a Phase 4 sprint,
+// long after everyone who read D4 has moved on — fails a test that names the
+// decision and points at the ADR.
+//
+// That test is the deliverable here. The types are how it gets something to
+// check.
+package devicesync
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// DeviceID identifies one of a player's machines.
+//
+// Minted locally on first run, stored in the settings table, and never derived
+// from hardware: a hardware-derived identity is a fingerprint, and a
+// local-first product that promises no telemetry should not be able to
+// recognise a machine it was never told about.
+type DeviceID string
+
+// Change is one status change, which is the only library fact that crosses.
+//
+// It carries a UID rather than a GameID because a local surrogate key means
+// nothing on another device — which is exactly why library.UID exists in
+// Phase 1 and why adding it in Phase 4 would have required a migration that
+// invents stable identities for rows whose titles the player had since edited.
+type Change struct {
+	// UID is the cross-device merge hint. It is a hint and not an authority:
+	// an ambiguous match is shown to the player, never guessed.
+	UID library.UID
+
+	// Status is the player's manual choice, or nil when they cleared the
+	// override. The nil is meaningful and must cross: "I have no opinion" is
+	// a change the player made.
+	Status *status.Status
+
+	// ChangedAt decides the conflict. Last-write-wins per game.
+	//
+	// The limits are stated rather than hidden: two devices that both change a
+	// status while offline lose the earlier change silently. That is adequate
+	// because the conflicting parties are one person on two devices who agree
+	// about what they did, and it is unacceptable to leave undocumented, so
+	// Z-22 shows the last merge and what it resolved.
+	ChangedAt time.Time
+}
+
+// ManualGame is a hand-entered game, which crosses because it is the one row
+// class with no other copy.
+//
+// Everything else in the library is re-derivable from the player's own
+// sources; a cartridge typed into Z-08 exists nowhere else, so losing it is
+// unrecoverable. D4 therefore puts these in the *first* sync payload rather
+// than a follow-up.
+//
+// Note what this struct does not have and cannot grow: no playtime, no
+// last-played, no cover, no provider ref, no credentials. A hand-entered
+// game's provider ref is a UUID this device minted and it means nothing on
+// another machine.
+type ManualGame struct {
+	UID       library.UID
+	Title     string
+	Platform  string
+	CreatedAt time.Time
+
+	// OwnedSince is the one optional field, because it is the one optional
+	// thing the player typed.
+	OwnedSince *time.Time
+}
+
+// Envelope is one direction of one exchange.
+type Envelope struct {
+	// Device is which machine this came from, so a merge can say what it
+	// resolved and against what.
+	Device DeviceID
+
+	// Since is the watermark the sender had before this exchange. The server
+	// returns everything after it; there is no full-library transfer because
+	// there is no library on the server to transfer.
+	Since time.Time
+
+	Changes []Change
+	Manual  []ManualGame
+}
+
+// Client is the Phase 1 sketch of the Phase 4 boundary.
+//
+// It is two calls because the payload is small and idempotent, and because
+// anything richer — a subscription, a stream, an operation log — would be
+// designing for a conflict shape that does not exist. D4 rejects CRDTs and
+// operation logs for exactly that reason: they are correct for concurrent
+// multi-writer editing, and the parties here are one person on two devices.
+//
+// What Phase 1 must not make impossible, and does not:
+//
+//   - a stable identity exists on every row from the first migration;
+//   - status_changed_at exists and is written on every change, including a
+//     clear;
+//   - merged_into exists so two rows can be joined without rewriting keys;
+//   - the store is the single writer, so a Phase 4 merge attaches at that
+//     seam without touching a screen.
+//
+// What is deliberately not decided here: whether Phase 4 accounts are
+// email-and-password, OAuth or something else. Nothing in Phase 1 depends on
+// it, and ADR-0001 names it as not decided.
+type Client interface {
+	// Push sends this device's changes since the last watermark.
+	Push(ctx context.Context, e Envelope) (Receipt, error)
+
+	// Pull returns other devices' changes since the watermark.
+	Pull(ctx context.Context, device DeviceID, since time.Time) (Envelope, error)
+}
+
+// Receipt is what the server acknowledges.
+type Receipt struct {
+	// Watermark is the new "since" for this device's next exchange.
+	Watermark time.Time
+
+	// Accepted and Superseded let Z-22 report what a merge actually did —
+	// which is the price of last-write-wins being an acceptable simplicity
+	// choice rather than a silent one.
+	Accepted   int
+	Superseded int
+}

--- a/internal/fault/classify.go
+++ b/internal/fault/classify.go
@@ -82,12 +82,34 @@ type Outcome struct {
 	MessageKey string
 }
 
-// Classify turns an Outcome into a Fault, implementing the decision tree in
+// Classify turns an Outcome into an error, implementing the decision tree in
 // 07-offline-contract.md §5.
 //
 // A nil return means success. Whether an empty result is itself a refusal is
 // the caller's business, and is answered by [ClassifySync] for the one
 // operation where it is — rather than by this function guessing.
+//
+// # Why it returns error and not *Fault
+//
+// It returned *Fault once, and that made the natural provider spelling a trap:
+//
+//	func (s *steam) sync(...) error { return fault.Classify(o) }
+//
+// A successful outcome returns a nil *Fault, which becomes a NON-nil error
+// interface holding a typed nil. [KindOf] then finds err != nil, errors.As
+// succeeds, the embedded pointer is nil — and reports KindInternal, so a
+// completely successful sync renders the fatal screen.
+//
+// It fails in the safe direction, loudly and in the "this is ours" direction,
+// which is the taxonomy working. But safe is not correct, and the repair is
+// the same one this package has now made twice elsewhere: make the guarantee a
+// property of the signature rather than of how carefully every caller holds
+// it. Returning error means the nil is an untyped nil at every call site,
+// including the ones nobody has written yet.
+//
+// Callers that need the classification ask [KindOf], [Is], [SubjectOf] or
+// [RetryAfterOf], which is the documented way to read a fault and works
+// through wrapping.
 //
 // The ordering of the branches is part of the contract:
 //
@@ -97,7 +119,7 @@ type Outcome struct {
 //     from the body;
 //  3. then 404 and 429, each of which has its own screen;
 //  4. then 5xx, then any other 4xx, which is our bug and not their outage.
-func Classify(o Outcome) *Fault {
+func Classify(o Outcome) error {
 	opts := []Option{WithSubject(o.Subject), WithCause(o.Cause), messageOverride(o.MessageKey)}
 
 	switch o.Transport {
@@ -151,7 +173,7 @@ func Classify(o Outcome) *Fault {
 // after which the screen would honestly report a catastrophe it had caused.
 // Returning a Fault here is what makes the ratified copy — "Your library is
 // unchanged — nothing was lost." — true at the moment it is printed.
-func ClassifySync(o Outcome) *Fault {
+func ClassifySync(o Outcome) error {
 	if f := Classify(o); f != nil {
 		return f
 	}

--- a/internal/fault/classify.go
+++ b/internal/fault/classify.go
@@ -1,0 +1,166 @@
+package fault
+
+import "time"
+
+// Transport is what the network layer observed, in the only four flavours the
+// offline contract's classifier distinguishes.
+//
+// It is an enum rather than an error because this package must not import net
+// or net/http. 07-offline-contract.md §7.3 makes "no net/http import outside
+// the provider packages" a review rule, and a shared classifier that reached
+// for *net.DNSError would be the first, most reasonable-looking violation of
+// it — after which the rule is a comment.
+//
+// So the provider, which is already the only package allowed to know about
+// HTTP, does the probing and reports a verdict. The classifier stays a pure
+// function over that verdict, which is also what makes every branch of it
+// reachable in a test with no network at all.
+type Transport uint8
+
+const (
+	// TransportOK means a response was received. Its status code decides the
+	// rest.
+	TransportOK Transport = iota
+
+	// TransportNoRoute means the request could not leave the machine: no
+	// route to host, network unreachable, interface down.
+	TransportNoRoute
+
+	// TransportDNS means the name did not resolve.
+	//
+	// Folded with TransportNoRoute at the treatment level — both are the
+	// OFFLINE banner — but kept distinct here because they are distinct
+	// facts, and a log that says which one is a log worth having.
+	TransportDNS
+
+	// TransportTimeout means the request was sent and nothing useful came
+	// back in time. This includes a body that stalled mid-stream.
+	TransportTimeout
+
+	// TransportReset means the connection was established and then broken.
+	TransportReset
+)
+
+// Outcome is everything the classifier needs to decide what a player is told.
+//
+// A provider fills it in and calls [Classify]. It is a struct rather than a
+// long parameter list because the fields are not interchangeable and three of
+// them are zero in the common case.
+type Outcome struct {
+	// Op is the operation name for logs — "steam.Sync".
+	Op string
+
+	// Subject is the player-facing name of the provider — "Steam".
+	Subject string
+
+	// Transport is the network-layer verdict.
+	Transport Transport
+
+	// Status is the HTTP status code, or 0 when no response arrived.
+	//
+	// A plain int precisely so this package needs no HTTP import. A non-HTTP
+	// provider reports 200 for success and 0 for "not applicable", and the
+	// classifier is unchanged.
+	Status int
+
+	// Items is how many items the operation yielded before it ended.
+	//
+	// This is the field that separates a private profile from a working sync
+	// of a small library, and it is why the classifier takes an Outcome
+	// rather than a response: a 200 that yielded nothing and a 200 that
+	// yielded 247 games are the same response and completely different facts.
+	Items int
+
+	// RetryAfter is the provider's own wait instruction, when it sent one.
+	RetryAfter time.Duration
+
+	// Cause is the underlying error, for logs. It is never rendered.
+	Cause error
+
+	// MessageKey optionally overrides the Kind's default catalogue entry, for
+	// a provider that has better copy for its own case.
+	MessageKey string
+}
+
+// Classify turns an Outcome into a Fault, implementing the decision tree in
+// 07-offline-contract.md §5.
+//
+// A nil return means success. Whether an empty result is itself a refusal is
+// the caller's business, and is answered by [ClassifySync] for the one
+// operation where it is — rather than by this function guessing.
+//
+// The ordering of the branches is part of the contract:
+//
+//  1. transport failures first — a rejected key is meaningless if the request
+//     never arrived;
+//  2. then 401/403, because a credential verdict outranks anything derivable
+//     from the body;
+//  3. then 404 and 429, each of which has its own screen;
+//  4. then 5xx, then any other 4xx, which is our bug and not their outage.
+func Classify(o Outcome) *Fault {
+	opts := []Option{WithSubject(o.Subject), WithCause(o.Cause), messageOverride(o.MessageKey)}
+
+	switch o.Transport {
+	case TransportNoRoute, TransportDNS:
+		return New(KindOffline, o.Op, opts...)
+	case TransportTimeout, TransportReset:
+		return New(KindUnreachable, o.Op, opts...)
+	}
+
+	switch {
+	case o.Status == 401 || o.Status == 403:
+		return New(KindUnauthorized, o.Op, opts...)
+	case o.Status == 404:
+		return New(KindNotFound, o.Op, opts...)
+	case o.Status == 429:
+		return New(KindRateLimited, o.Op, append(opts, WithRetryAfter(o.RetryAfter))...)
+	case o.Status >= 500:
+		return New(KindUnreachable, o.Op, opts...)
+	case o.Status >= 400:
+		// A 4xx that is not one of the three above means Zerado sent
+		// something the provider would not accept. That is our bug, not the
+		// player's network, and it must not be dressed as one.
+		return New(KindMalformed, o.Op, opts...)
+	case o.Status >= 200 && o.Status < 300:
+		return nil
+	case o.Status == 0:
+		// No response and no transport verdict is a provider that did not
+		// fill in its Outcome. Refusing to guess is the whole point of the
+		// taxonomy.
+		return New(KindInternal, o.Op, opts...)
+	default:
+		return New(KindMalformed, o.Op, opts...)
+	}
+}
+
+// ClassifySync is Classify with the one rule that applies only to a library
+// fetch: a successful response carrying zero items is a refusal, not an empty
+// result.
+//
+// This is the private-profile case, and it is a separate function rather than
+// a branch inside Classify because emptiness is a refusal for exactly one
+// operation. A metadata lookup that finds nothing renders the designed
+// no-metadata composition; a price lookup that finds no quote is simply no
+// quote. Only a library sync may conclude, from an empty answer, that the
+// player has to go and change a setting somewhere else.
+//
+// Its consequence is load-bearing rather than cosmetic. 06-data-seams.md §2.4
+// forbids tombstoning on any run that is not ok, and Z-03 §8.2 spells out why:
+// a 247-game library whose owner has just made their profile private would
+// otherwise be deleted by a naive "the provider's view is the truth" upsert,
+// after which the screen would honestly report a catastrophe it had caused.
+// Returning a Fault here is what makes the ratified copy — "Your library is
+// unchanged — nothing was lost." — true at the moment it is printed.
+func ClassifySync(o Outcome) *Fault {
+	if f := Classify(o); f != nil {
+		return f
+	}
+	if o.Items == 0 {
+		return New(KindEmpty, o.Op,
+			WithSubject(o.Subject),
+			WithCause(o.Cause),
+			messageOverride(o.MessageKey),
+		)
+	}
+	return nil
+}

--- a/internal/fault/classify_test.go
+++ b/internal/fault/classify_test.go
@@ -1,0 +1,96 @@
+package fault_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+)
+
+// TestClassifyFollowsTheOfflineContract walks 07-offline-contract.md §5's
+// decision tree, every branch, with no network involved — which is the point:
+// the classifier is a pure function over a verdict the provider supplies, so
+// it does not import net or net/http and every branch is reachable in a test.
+func TestClassifyFollowsTheOfflineContract(t *testing.T) {
+	cases := []struct {
+		name string
+		out  fault.Outcome
+		want fault.Kind
+	}{
+		{"no route", fault.Outcome{Transport: fault.TransportNoRoute}, fault.KindOffline},
+		{"DNS did not resolve", fault.Outcome{Transport: fault.TransportDNS}, fault.KindOffline},
+		{"timeout", fault.Outcome{Transport: fault.TransportTimeout}, fault.KindUnreachable},
+		{"connection reset mid-body", fault.Outcome{Transport: fault.TransportReset}, fault.KindUnreachable},
+		{"401", fault.Outcome{Status: 401}, fault.KindUnauthorized},
+		{"403", fault.Outcome{Status: 403}, fault.KindUnauthorized},
+		{"404", fault.Outcome{Status: 404}, fault.KindNotFound},
+		{"429", fault.Outcome{Status: 429}, fault.KindRateLimited},
+		{"500", fault.Outcome{Status: 500}, fault.KindUnreachable},
+		{"503", fault.Outcome{Status: 503}, fault.KindUnreachable},
+		{"400 — our request, not their outage", fault.Outcome{Status: 400}, fault.KindMalformed},
+		{"no response and no verdict", fault.Outcome{}, fault.KindInternal},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.out.Op = "steam.Sync"
+			f := fault.Classify(c.out)
+			if f == nil {
+				t.Fatalf("Classify returned success for %s", c.name)
+			}
+			if f.Kind != c.want {
+				t.Fatalf("Classify(%s) = %v, want %v", c.name, f.Kind, c.want)
+			}
+		})
+	}
+
+	if f := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 200}); f != nil {
+		t.Fatalf("a 200 classified as %v", f.Kind)
+	}
+}
+
+// TestTransportOutranksStatus: a rejected key is meaningless if the request
+// never arrived, so the transport branch is consulted first.
+func TestTransportOutranksStatus(t *testing.T) {
+	f := fault.Classify(fault.Outcome{Op: "steam.Sync", Transport: fault.TransportNoRoute, Status: 401})
+	if f.Kind != fault.KindOffline {
+		t.Fatalf("got %v; a 401 recorded alongside a failed transport is not a credential verdict", f.Kind)
+	}
+}
+
+// TestAnEmptySyncIsARefusal is the guard behind the ratified copy "Your
+// library is unchanged — nothing was lost." A 200 carrying zero items is the
+// private-profile case, and treating it as an empty result set would delete a
+// 247-game library.
+func TestAnEmptySyncIsARefusal(t *testing.T) {
+	f := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Subject: "Steam", Status: 200, Items: 0})
+	if f == nil {
+		t.Fatal("a successful, empty library sync reported success; the upsert would then have emptied the library")
+	}
+	if f.Kind != fault.KindEmpty {
+		t.Fatalf("got %v, want KindEmpty", f.Kind)
+	}
+	if f.Subject != "Steam" {
+		t.Fatalf("the subject was lost; the copy needs it as a substitution")
+	}
+
+	if f := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Status: 200, Items: 1}); f != nil {
+		t.Fatalf("a one-item library classified as %v", f.Kind)
+	}
+}
+
+// TestEmptinessIsOnlyARefusalForASync: a metadata lookup that finds nothing is
+// a designed empty, and only a library fetch may conclude that the player must
+// go and change a setting somewhere else.
+func TestEmptinessIsOnlyARefusalForASync(t *testing.T) {
+	if f := fault.Classify(fault.Outcome{Op: "meta.Lookup", Status: 200, Items: 0}); f != nil {
+		t.Fatalf("a non-sync operation treated emptiness as a refusal: %v", f.Kind)
+	}
+}
+
+// TestRateLimitCarriesTheProvidersWait.
+func TestRateLimitCarriesTheProvidersWait(t *testing.T) {
+	f := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 429, RetryAfter: 30 * time.Second})
+	if f.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", f.RetryAfter)
+	}
+}

--- a/internal/fault/classify_test.go
+++ b/internal/fault/classify_test.go
@@ -33,27 +33,27 @@ func TestClassifyFollowsTheOfflineContract(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			c.out.Op = "steam.Sync"
-			f := fault.Classify(c.out)
-			if f == nil {
+			err := fault.Classify(c.out)
+			if err == nil {
 				t.Fatalf("Classify returned success for %s", c.name)
 			}
-			if f.Kind != c.want {
-				t.Fatalf("Classify(%s) = %v, want %v", c.name, f.Kind, c.want)
+			if got := fault.KindOf(err); got != c.want {
+				t.Fatalf("Classify(%s) = %v, want %v", c.name, got, c.want)
 			}
 		})
 	}
 
-	if f := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 200}); f != nil {
-		t.Fatalf("a 200 classified as %v", f.Kind)
+	if err := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 200}); err != nil {
+		t.Fatalf("a 200 classified as %v", fault.KindOf(err))
 	}
 }
 
 // TestTransportOutranksStatus: a rejected key is meaningless if the request
 // never arrived, so the transport branch is consulted first.
 func TestTransportOutranksStatus(t *testing.T) {
-	f := fault.Classify(fault.Outcome{Op: "steam.Sync", Transport: fault.TransportNoRoute, Status: 401})
-	if f.Kind != fault.KindOffline {
-		t.Fatalf("got %v; a 401 recorded alongside a failed transport is not a credential verdict", f.Kind)
+	err := fault.Classify(fault.Outcome{Op: "steam.Sync", Transport: fault.TransportNoRoute, Status: 401})
+	if got := fault.KindOf(err); got != fault.KindOffline {
+		t.Fatalf("got %v; a 401 recorded alongside a failed transport is not a credential verdict", got)
 	}
 }
 
@@ -62,19 +62,19 @@ func TestTransportOutranksStatus(t *testing.T) {
 // private-profile case, and treating it as an empty result set would delete a
 // 247-game library.
 func TestAnEmptySyncIsARefusal(t *testing.T) {
-	f := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Subject: "Steam", Status: 200, Items: 0})
-	if f == nil {
+	err := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Subject: "Steam", Status: 200, Items: 0})
+	if err == nil {
 		t.Fatal("a successful, empty library sync reported success; the upsert would then have emptied the library")
 	}
-	if f.Kind != fault.KindEmpty {
-		t.Fatalf("got %v, want KindEmpty", f.Kind)
+	if got := fault.KindOf(err); got != fault.KindEmpty {
+		t.Fatalf("got %v, want KindEmpty", got)
 	}
-	if f.Subject != "Steam" {
-		t.Fatalf("the subject was lost; the copy needs it as a substitution")
+	if got := fault.SubjectOf(err); got != "Steam" {
+		t.Fatalf("the subject was lost (%q); the copy needs it as a substitution", got)
 	}
 
-	if f := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Status: 200, Items: 1}); f != nil {
-		t.Fatalf("a one-item library classified as %v", f.Kind)
+	if err := fault.ClassifySync(fault.Outcome{Op: "steam.Sync", Status: 200, Items: 1}); err != nil {
+		t.Fatalf("a one-item library classified as %v", fault.KindOf(err))
 	}
 }
 
@@ -82,15 +82,53 @@ func TestAnEmptySyncIsARefusal(t *testing.T) {
 // a designed empty, and only a library fetch may conclude that the player must
 // go and change a setting somewhere else.
 func TestEmptinessIsOnlyARefusalForASync(t *testing.T) {
-	if f := fault.Classify(fault.Outcome{Op: "meta.Lookup", Status: 200, Items: 0}); f != nil {
-		t.Fatalf("a non-sync operation treated emptiness as a refusal: %v", f.Kind)
+	if err := fault.Classify(fault.Outcome{Op: "meta.Lookup", Status: 200, Items: 0}); err != nil {
+		t.Fatalf("a non-sync operation treated emptiness as a refusal: %v", fault.KindOf(err))
 	}
 }
 
 // TestRateLimitCarriesTheProvidersWait.
 func TestRateLimitCarriesTheProvidersWait(t *testing.T) {
-	f := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 429, RetryAfter: 30 * time.Second})
-	if f.RetryAfter != 30*time.Second {
-		t.Fatalf("RetryAfter = %v, want 30s", f.RetryAfter)
+	err := fault.Classify(fault.Outcome{Op: "steam.Sync", Status: 429, RetryAfter: 30 * time.Second})
+	if got := fault.RetryAfterOf(err); got != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", got)
+	}
+}
+
+// TestClassifySuccessIsAnUntypedNil is the MINOR-3 repair from the review at
+// 4484d9a, pinned.
+//
+// Classify used to return *Fault, which made the natural provider spelling —
+// `return fault.Classify(o)` from a function returning error — hand back a
+// non-nil error interface wrapping a typed nil on SUCCESS. KindOf then
+// reported KindInternal, so a completely successful sync would have rendered
+// the fatal screen.
+//
+// The check is deliberately the one a caller performs, `err != nil`, on a
+// value that has passed through an error-returning function — because that is
+// the exact conversion that created the trap, and a direct comparison against
+// the concrete return type would not have caught it.
+func TestClassifySuccessIsAnUntypedNil(t *testing.T) {
+	viaFunc := func(o fault.Outcome) error { return fault.Classify(o) }
+	viaSync := func(o fault.Outcome) error { return fault.ClassifySync(o) }
+
+	ok := fault.Outcome{Op: "steam.Sync", Status: 200, Items: 12}
+	for name, got := range map[string]error{
+		"Classify":     viaFunc(ok),
+		"ClassifySync": viaSync(ok),
+	} {
+		if got != nil {
+			t.Fatalf("%s: a successful outcome produced a non-nil error (%v, kind %v).\n"+
+				"If this is a typed nil, every caller that returns it as an error reports a\n"+
+				"successful sync as KindInternal and renders Z-11.", name, got, fault.KindOf(got))
+		}
+		if k := fault.KindOf(got); k != fault.KindUnknown {
+			t.Fatalf("%s: KindOf(success) = %v, want KindUnknown", name, k)
+		}
+	}
+
+	// And the failing path still classifies through the same conversion.
+	if k := fault.KindOf(viaFunc(fault.Outcome{Op: "steam.Sync", Status: 401})); k != fault.KindUnauthorized {
+		t.Fatalf("through an error-returning function, a 401 classified as %v", k)
 	}
 }

--- a/internal/fault/fault.go
+++ b/internal/fault/fault.go
@@ -1,0 +1,201 @@
+package fault
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/i18n"
+)
+
+// Fault is the one error type every Zerado seam returns.
+//
+// Callers are not expected to type-assert it. They ask [Is] or [KindOf], both
+// of which see through wrapping, so a package may wrap a Fault in context
+// without breaking the caller's switch. The struct is exported because a
+// provider package has to build one, not because a screen should read one.
+//
+// # What a Fault may and may not carry
+//
+// It may carry: a Kind, a machine-readable operation name, the subject the
+// message is about, an i18n key, a retry hint, and a wrapped cause.
+//
+// It may not carry a sentence. ADR-0001 D9 forbids user-facing string
+// literals in code, and D9's lint cannot see a literal that has been parked in
+// an error struct. The Kind chooses the treatment, the MessageKey chooses the
+// words, and the catalogue owns every word.
+//
+// It may not carry a credential, a URL with a query string, or anything else
+// derived from the player's keys. That rule is about Cause: an HTTP client's
+// own *url.Error stringifies the full URL, and a Steam URL carries the API key
+// in it. See [Fault.Error].
+type Fault struct {
+	// Kind is the taxonomy member. It is required; a Fault with KindUnknown is
+	// a construction bug and [New] refuses to make one.
+	Kind Kind
+
+	// Op names the operation that failed, in package.Method form —
+	// "steam.Sync", "store.UpsertBatch", "vault.Get".
+	//
+	// It is for logs, for the CLI's --json envelope and for test failures. It
+	// is never rendered to a player: a person who has just been told their
+	// Steam profile is private does not need to know which Go method noticed.
+	Op string
+
+	// Subject is what the message is about, in the player's terms — the value
+	// a Provider's Display() returns, so "Steam" and not "steam".
+	//
+	// It is a substitution for the catalogue, not a message. Copy such as
+	// "Steam didn't answer" is one catalogue entry with a {subject} argument,
+	// which is what makes the same entry correct for GOG on the day GOG
+	// exists, in every language, with no new key.
+	Subject string
+
+	// MessageKey names the catalogue entry that renders this fault.
+	//
+	// A Kind has a default key (see [Kind.MessageKey]); a provider may
+	// override it when it has genuinely better copy for its own case. The
+	// override is why this is a field rather than a pure function of Kind:
+	// Steam's private-profile refusal names a specific Steam privacy setting,
+	// which no generic KindEmpty copy could.
+	MessageKey i18n.Key
+
+	// RetryAfter is the provider's own instruction to wait, when it gave one.
+	//
+	// Zero means "not stated", never "retry immediately". Only meaningful
+	// with KindRateLimited, and it is the reason KindRateLimited is a distinct
+	// Kind rather than a flavour of KindUnreachable.
+	RetryAfter time.Duration
+
+	// Cause is the underlying error, for logs and for errors.Is/As by the
+	// package that built the Fault.
+	//
+	// It is never rendered. See [Fault.Error] for why that is a redaction
+	// requirement and not a style preference.
+	Cause error
+}
+
+// New builds a Fault.
+//
+// It panics on an invalid Kind. That is deliberate and it is the only panic in
+// these contracts: an unclassified failure is a hole in the taxonomy, the hole
+// is a screen nobody designed, and a construction-site panic in a test run is
+// enormously cheaper than shipping a banner that says nothing.
+func New(kind Kind, op string, opts ...Option) *Fault {
+	if !kind.Valid() {
+		panic(fmt.Sprintf("fault.New: invalid kind %d for op %q", kind, op))
+	}
+	f := &Fault{Kind: kind, Op: op, MessageKey: kind.MessageKey()}
+	for _, o := range opts {
+		o(f)
+	}
+	return f
+}
+
+// Option customises a Fault at construction.
+//
+// Options rather than a wide constructor, because the common call is two
+// arguments and the rare call is five, and a five-argument constructor with
+// three zero values at every site is how Subject silently stops being filled.
+type Option func(*Fault)
+
+// WithSubject sets the player-facing subject — a provider's Display() value.
+func WithSubject(s string) Option { return func(f *Fault) { f.Subject = s } }
+
+// WithMessage overrides the Kind's default catalogue key.
+func WithMessage(k i18n.Key) Option { return func(f *Fault) { f.MessageKey = k } }
+
+// WithRetryAfter records a provider's own wait instruction.
+func WithRetryAfter(d time.Duration) Option { return func(f *Fault) { f.RetryAfter = d } }
+
+// WithCause attaches the underlying error for logs and errors.Is.
+func WithCause(err error) Option { return func(f *Fault) { f.Cause = err } }
+
+// Error returns a developer-facing description. It is a log line, not a
+// message.
+//
+// It deliberately does not include Cause's text. An *url.Error from net/http
+// stringifies the whole URL, and Steam's URLs carry the player's API key as a
+// query parameter — so an error string that concatenates its cause is a
+// credential-disclosure path that runs straight through the one screen a
+// frustrated player is most likely to screenshot and paste into a bug report.
+//
+// The cause is still reachable by [errors.Unwrap] and by errors.Is/As, which
+// is where a log sink that has been told it may see it can get it.
+func (f *Fault) Error() string {
+	if f == nil {
+		return "<nil fault>"
+	}
+	if f.Subject != "" {
+		return fmt.Sprintf("%s: %s: %s", f.Op, f.Subject, f.Kind)
+	}
+	return fmt.Sprintf("%s: %s", f.Op, f.Kind)
+}
+
+// Unwrap returns the wrapped cause, so errors.Is and errors.As reach it.
+func (f *Fault) Unwrap() error {
+	if f == nil {
+		return nil
+	}
+	return f.Cause
+}
+
+// Is reports whether err is, or wraps, a Fault of the given Kind.
+//
+// This is the call every caller makes. It is a function rather than a method
+// so that no caller has to have already established that it holds a Fault, and
+// it walks the wrap chain so that a package adding context to a provider's
+// error does not silently reclassify it.
+func Is(err error, k Kind) bool { return KindOf(err) == k }
+
+// KindOf returns the Kind of err, walking the wrap chain.
+//
+// It returns KindInternal for a non-nil error that is not a Fault, because an
+// error that reached a screen without ever having been classified is exactly
+// the case Z-11 exists for — and reporting it as, say, KindUnreachable would
+// be a guess about somebody else's failure.
+//
+// It returns KindUnknown for a nil error, which is the one place KindUnknown
+// is a legitimate value: it means "nothing failed".
+func KindOf(err error) Kind {
+	if err == nil {
+		return KindUnknown
+	}
+	var f *Fault
+	if errors.As(err, &f) && f != nil {
+		return f.Kind
+	}
+	return KindInternal
+}
+
+// RetryAfterOf returns the wait a provider asked for, or zero if none was
+// stated.
+func RetryAfterOf(err error) time.Duration {
+	var f *Fault
+	if errors.As(err, &f) && f != nil {
+		return f.RetryAfter
+	}
+	return 0
+}
+
+// MessageKeyOf returns the catalogue key that renders err.
+//
+// A non-Fault error yields the internal-failure key rather than an empty one,
+// so there is no path by which an unclassified error renders as a blank
+// screen.
+func MessageKeyOf(err error) i18n.Key {
+	var f *Fault
+	if errors.As(err, &f) && f != nil && f.MessageKey.Valid() {
+		return f.MessageKey
+	}
+	return KindInternal.MessageKey()
+}
+
+// SubjectOf returns the player-facing subject carried by err, if any.
+func SubjectOf(err error) string {
+	var f *Fault
+	if errors.As(err, &f) && f != nil {
+		return f.Subject
+	}
+	return ""
+}

--- a/internal/fault/fault.go
+++ b/internal/fault/fault.go
@@ -202,16 +202,27 @@ func MessageKeyOf(err error) i18n.Key {
 // has an exported URL field, and a Steam URL carries the player's API key in
 // its query string.
 //
-// So the redaction is moved into the type, where it holds for every caller
-// including the ones that have not been written yet. The cause stays reachable
-// through errors.Is and errors.As for a sink that has been told it may see it.
+// # Why a value receiver
+//
+// The first version of this method took a pointer receiver, and that made the
+// redaction a property of the pointer rather than of the type. encoding/json
+// does not invoke a pointer method for a non-addressable value, so
+// json.Marshal of a Fault VALUE — or of a struct that embeds one, which is
+// exactly the log-sink case named above — fell back to reflection over the
+// exported fields and emitted the whole cause, URL and key included.
+//
+// A value receiver is in the method set of both Fault and *Fault, so every
+// spelling redacts. Nothing in this module could reach the value path (New
+// returns a pointer and no caller dereferences), which is why it was found by
+// probing rather than by a failure — and why the test below probes all three
+// spellings rather than the one the code happens to use today.
+//
+// The cause stays reachable through errors.Is and errors.As for a sink that
+// has been told it may see it.
 //
 // The shape matches the CLI's ErrorBody deliberately: one machine-readable
 // description of a failure, in one shape, wherever it is serialised.
-func (f *Fault) MarshalJSON() ([]byte, error) {
-	if f == nil {
-		return []byte("null"), nil
-	}
+func (f Fault) MarshalJSON() ([]byte, error) {
 	out := struct {
 		Kind              string `json:"kind"`
 		Op                string `json:"op,omitempty"`

--- a/internal/fault/fault.go
+++ b/internal/fault/fault.go
@@ -1,6 +1,7 @@
 package fault
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -189,6 +190,44 @@ func MessageKeyOf(err error) i18n.Key {
 		return f.MessageKey
 	}
 	return KindInternal.MessageKey()
+}
+
+// MarshalJSON renders a Fault without its cause.
+//
+// [Fault.Error] already redacts, and the CLI envelope is built field by field
+// from the accessors rather than from this type — both paths are tested. This
+// exists because neither of those is a property of the *type*: a log sink, a
+// future debug verb, or anything else that reaches for json.Marshal on a Fault
+// would reopen the exact path the rest of this package closes. An *url.Error
+// has an exported URL field, and a Steam URL carries the player's API key in
+// its query string.
+//
+// So the redaction is moved into the type, where it holds for every caller
+// including the ones that have not been written yet. The cause stays reachable
+// through errors.Is and errors.As for a sink that has been told it may see it.
+//
+// The shape matches the CLI's ErrorBody deliberately: one machine-readable
+// description of a failure, in one shape, wherever it is serialised.
+func (f *Fault) MarshalJSON() ([]byte, error) {
+	if f == nil {
+		return []byte("null"), nil
+	}
+	out := struct {
+		Kind              string `json:"kind"`
+		Op                string `json:"op,omitempty"`
+		Subject           string `json:"subject,omitempty"`
+		MessageKey        string `json:"message_key,omitempty"`
+		RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
+	}{
+		Kind:       f.Kind.String(),
+		Op:         f.Op,
+		Subject:    f.Subject,
+		MessageKey: f.MessageKey.String(),
+	}
+	if f.RetryAfter > 0 {
+		out.RetryAfterSeconds = int(f.RetryAfter.Seconds())
+	}
+	return json.Marshal(out)
 }
 
 // SubjectOf returns the player-facing subject carried by err, if any.

--- a/internal/fault/fault_test.go
+++ b/internal/fault/fault_test.go
@@ -1,0 +1,175 @@
+package fault_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+)
+
+// TestTaxonomyIsTotal fails the moment somebody adds a Kind without deciding
+// what it looks like on screen. Every member needs a name, a treatment and a
+// catalogue key, and no two may share a name.
+func TestTaxonomyIsTotal(t *testing.T) {
+	seen := map[string]fault.Kind{}
+	for _, k := range fault.Kinds() {
+		if !k.Valid() {
+			t.Errorf("%v is in Kinds() but reports itself invalid", k)
+		}
+		name := k.String()
+		if name == "" || name == "unknown" {
+			t.Errorf("kind %d has no stable machine name", k)
+		}
+		if prev, dup := seen[name]; dup {
+			t.Errorf("kinds %v and %v share the machine name %q; the CLI cannot distinguish them", prev, k, name)
+		}
+		seen[name] = k
+		if !k.MessageKey().Valid() {
+			t.Errorf("%v has no catalogue key; it would render as a blank message", k)
+		}
+	}
+	if len(fault.Kinds()) != len(seen) {
+		t.Fatalf("Kinds() has %d entries but %d distinct names", len(fault.Kinds()), len(seen))
+	}
+}
+
+// TestAPrivateProfileIsNotANetworkError is the case this whole package exists
+// for. Four failures that a bare error string would flatten into one must be
+// four distinguishable kinds with three different screen treatments.
+func TestAPrivateProfileIsNotANetworkError(t *testing.T) {
+	private := fault.New(fault.KindEmpty, "steam.Sync", fault.WithSubject("Steam"))
+	offline := fault.New(fault.KindOffline, "steam.Sync", fault.WithSubject("Steam"))
+	unreachable := fault.New(fault.KindUnreachable, "steam.Sync", fault.WithSubject("Steam"))
+	rejected := fault.New(fault.KindUnauthorized, "steam.Sync", fault.WithSubject("Steam"))
+
+	all := []*fault.Fault{private, offline, unreachable, rejected}
+	for i, a := range all {
+		for j, b := range all {
+			if i != j && a.Kind == b.Kind {
+				t.Fatalf("two of the four Z-03 failures share a kind: %v", a.Kind)
+			}
+		}
+	}
+
+	if fault.Is(private, fault.KindOffline) || fault.Is(private, fault.KindUnreachable) {
+		t.Fatal("a private profile classified as a network failure")
+	}
+	if private.Kind.Treatment() != fault.TreatmentRefusal {
+		t.Fatalf("a private profile renders as %v; it is an action the player took and is owed a refusal", private.Kind.Treatment())
+	}
+	if offline.Kind.Treatment() != fault.TreatmentBanner {
+		t.Fatalf("being offline renders as %v; it is ambient and belongs in the banner", offline.Kind.Treatment())
+	}
+	if private.Kind.Retryable() {
+		t.Fatal("a private profile is retryable; pressing r changes nothing until the player changes a setting elsewhere")
+	}
+	if !offline.Kind.Retryable() {
+		t.Fatal("being offline is not retryable; the banner would offer no way out")
+	}
+}
+
+// TestNotFoundIsADesignedEmpty guards 06 §3.1: no metadata is a composition,
+// not an error banner.
+func TestNotFoundIsADesignedEmpty(t *testing.T) {
+	if got := fault.KindNotFound.Treatment(); got != fault.TreatmentDesignedEmpty {
+		t.Fatalf("KindNotFound renders as %v; a cartridge no source has heard of is not a failure", got)
+	}
+}
+
+// TestCancelledIsNotAnError guards Z-03's CANCELLED state: no cue, no red, no
+// apology.
+func TestCancelledIsNotAnError(t *testing.T) {
+	if got := fault.KindCancelled.Treatment(); got != fault.TreatmentNone {
+		t.Fatalf("KindCancelled renders as %v; the player did it on purpose", got)
+	}
+}
+
+// TestKindSurvivesWrapping is the reason callers use fault.Is rather than a
+// type assertion: a package adding context must not reclassify a failure.
+func TestKindSurvivesWrapping(t *testing.T) {
+	base := fault.New(fault.KindUnauthorized, "steam.Sync")
+	wrapped := fmt.Errorf("while syncing the library: %w", base)
+	if !fault.Is(wrapped, fault.KindUnauthorized) {
+		t.Fatal("wrapping lost the kind")
+	}
+	if got := fault.KindOf(wrapped); got != fault.KindUnauthorized {
+		t.Fatalf("KindOf(wrapped) = %v", got)
+	}
+}
+
+// TestUnclassifiedIsInternal: an error that reached a screen without ever
+// being classified routes to the fatal screen rather than being guessed at.
+func TestUnclassifiedIsInternal(t *testing.T) {
+	if got := fault.KindOf(errors.New("boom")); got != fault.KindInternal {
+		t.Fatalf("an unclassified error reported %v; guessing somebody else's failure is worse than saying it is ours", got)
+	}
+	if got := fault.KindOf(nil); got != fault.KindUnknown {
+		t.Fatalf("KindOf(nil) = %v, want KindUnknown", got)
+	}
+	if !fault.MessageKeyOf(errors.New("boom")).Valid() {
+		t.Fatal("an unclassified error has no catalogue key; it would render blank")
+	}
+}
+
+// TestErrorDoesNotLeakTheCause is a credential-disclosure guard, not a style
+// preference. A provider's transport error stringifies a URL, and a Steam URL
+// carries the API key in its query string — straight into the one screen a
+// frustrated player screenshots.
+func TestErrorDoesNotLeakTheCause(t *testing.T) {
+	leak := errors.New(`Get "https://api.steampowered.com/x?key=SECRET-KEY-9F2": dial tcp: no route`)
+	f := fault.New(fault.KindOffline, "steam.Sync", fault.WithSubject("Steam"), fault.WithCause(leak))
+
+	if got := f.Error(); contains(got, "SECRET-KEY-9F2") {
+		t.Fatalf("Fault.Error() leaked the credential: %q", got)
+	}
+	if !errors.Is(f, leak) {
+		t.Fatal("the cause is unreachable by errors.Is; a log sink could not get it")
+	}
+}
+
+func contains(hay, needle string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRetryAfterTravels: a rate limit is a distinct kind precisely because it
+// carries a wait, and the wait has to survive to the CLI envelope.
+func TestRetryAfterTravels(t *testing.T) {
+	f := fault.New(fault.KindRateLimited, "steam.Sync", fault.WithRetryAfter(90*time.Second))
+	if got := fault.RetryAfterOf(f); got != 90*time.Second {
+		t.Fatalf("RetryAfterOf = %v, want 90s", got)
+	}
+	if got := fault.RetryAfterOf(fault.New(fault.KindOffline, "x")); got != 0 {
+		t.Fatalf("an unstated wait reported %v; zero must mean 'not stated', never 'retry now'", got)
+	}
+}
+
+// TestNewRefusesAnInvalidKind: an unclassified failure is a hole in the
+// taxonomy, and a panic at the construction site is cheaper than a banner
+// nobody designed.
+func TestNewRefusesAnInvalidKind(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("fault.New accepted KindUnknown")
+		}
+	}()
+	_ = fault.New(fault.KindUnknown, "somewhere")
+}
+
+// TestProviderOverridesCopy: Steam's private-profile refusal names a specific
+// Steam privacy setting, which no provider-agnostic entry could.
+func TestProviderOverridesCopy(t *testing.T) {
+	f := fault.New(fault.KindEmpty, "steam.Sync", fault.WithMessage("fault.steam.profile_private"))
+	if got := fault.MessageKeyOf(f); got != "fault.steam.profile_private" {
+		t.Fatalf("MessageKeyOf = %q; a provider must be able to supply better copy for its own case", got)
+	}
+	if fault.MessageKeyOf(fault.New(fault.KindEmpty, "gog.Sync")) != fault.KindEmpty.MessageKey() {
+		t.Fatal("a provider that supplies no copy must still render a sentence")
+	}
+}

--- a/internal/fault/fault_test.go
+++ b/internal/fault/fault_test.go
@@ -240,7 +240,7 @@ func TestMarshallingAFaultDropsTheCause(t *testing.T) {
 	f := fault.New(fault.KindRateLimited, "steam.Sync",
 		fault.WithSubject("Steam"), fault.WithCause(leak), fault.WithRetryAfter(30*time.Second))
 
-	// All three spellings, because the first version of MarshalJSON took a
+	// All four spellings, because the first version of MarshalJSON took a
 	// pointer receiver and only the first of these redacted. encoding/json
 	// does not invoke a pointer method for a non-addressable value, so the
 	// value and embedded forms fell back to reflection over the exported

--- a/internal/fault/fault_test.go
+++ b/internal/fault/fault_test.go
@@ -1,6 +1,7 @@
 package fault_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -173,3 +174,101 @@ func TestProviderOverridesCopy(t *testing.T) {
 		t.Fatal("a provider that supplies no copy must still render a sentence")
 	}
 }
+
+// TestKindsCoversTheWholeRange is the assertion that MAJOR-1 of the review at
+// c4c8d95 falsified.
+//
+// Kinds() used to be a hand-maintained slice while Valid() was derived from
+// the iota range, so the two could disagree — and a Kind inserted mid-block
+// was valid, constructible, and absent from every totality test. Kinds() is
+// now derived from the same range, and this asserts the two agree so that a
+// future contributor who reintroduces a literal slice fails here.
+func TestKindsCoversTheWholeRange(t *testing.T) {
+	listed := map[fault.Kind]bool{}
+	for _, k := range fault.Kinds() {
+		listed[k] = true
+	}
+	for k := fault.KindOffline; k <= fault.KindInternal; k++ {
+		if !listed[k] {
+			t.Errorf("kind %d is valid and constructible but is not in Kinds(); "+
+				"every totality test iterates Kinds() and would not see it", k)
+		}
+	}
+	if len(fault.Kinds()) != int(fault.KindInternal) {
+		t.Fatalf("Kinds() has %d entries but the taxonomy runs to %d",
+			len(fault.Kinds()), int(fault.KindInternal))
+	}
+	if listed[fault.KindUnknown] {
+		t.Fatal("KindUnknown is in Kinds(); it is never a member of the taxonomy")
+	}
+}
+
+// TestNoKindFallsThroughToTheDefaults is the other half of the same repair.
+//
+// String, Treatment and MessageKey are switches with defaults, and a Kind that
+// nobody added a case for inherits all three silently: the machine name
+// "unknown" on a surface the CLI documents as stable API, the fatal treatment,
+// and generic internal copy. Only KindInternal is entitled to those, so
+// everything else claiming one is an unfinished addition.
+func TestNoKindFallsThroughToTheDefaults(t *testing.T) {
+	for _, k := range fault.Kinds() {
+		if k == fault.KindInternal {
+			continue // the defaults are its real answers
+		}
+		if got := k.String(); got == "unknown" {
+			t.Errorf("kind %d has no case in String(); it would appear in the CLI's JSON as %q", k, got)
+		}
+		if got := k.MessageKey(); got == fault.KindInternal.MessageKey() {
+			t.Errorf("kind %d has no case in MessageKey(); it would render the internal-failure copy", k)
+		}
+		if got := k.Treatment(); got == fault.TreatmentFatal {
+			t.Errorf("kind %d has no case in Treatment(); it would stop the program", k)
+		}
+	}
+}
+
+// TestMarshallingAFaultDropsTheCause makes the redaction a property of the
+// type rather than of every call site.
+//
+// Fault.Error and the CLI envelope both redact and both are tested, but
+// neither protects a caller that has not been written yet — a log sink, a
+// future debug verb, anything that reaches for json.Marshal. An *url.Error has
+// an exported URL field, and a Steam URL carries the player's API key in its
+// query string.
+func TestMarshallingAFaultDropsTheCause(t *testing.T) {
+	leak := &leakyError{URL: "https://api.steampowered.com/x?key=SECRET-KEY-9F2"}
+	f := fault.New(fault.KindRateLimited, "steam.Sync",
+		fault.WithSubject("Steam"), fault.WithCause(leak), fault.WithRetryAfter(30*time.Second))
+
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, forbidden := range []string{"SECRET-KEY-9F2", "api.steampowered.com", "Cause", "cause"} {
+		if contains(string(b), forbidden) {
+			t.Fatalf("marshalling a Fault leaked %q: %s", forbidden, b)
+		}
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["kind"] != "rate_limited" {
+		t.Fatalf("kind = %v", got["kind"])
+	}
+	if got["retry_after_seconds"] != float64(30) {
+		t.Fatalf("retry_after_seconds = %v; the one field a scripted caller acts on was dropped", got["retry_after_seconds"])
+	}
+	if _, err := json.Marshal((*fault.Fault)(nil)); err != nil {
+		t.Fatalf("marshalling a nil Fault: %v", err)
+	}
+}
+
+// leakyError mimics *url.Error: an exported field carrying a credential-bearing
+// URL, which is what makes a naive json.Marshal a disclosure path.
+type leakyError struct {
+	URL string
+}
+
+func (e *leakyError) Error() string { return "Get " + e.URL + ": dial tcp: no route" }

--- a/internal/fault/fault_test.go
+++ b/internal/fault/fault_test.go
@@ -240,16 +240,34 @@ func TestMarshallingAFaultDropsTheCause(t *testing.T) {
 	f := fault.New(fault.KindRateLimited, "steam.Sync",
 		fault.WithSubject("Steam"), fault.WithCause(leak), fault.WithRetryAfter(30*time.Second))
 
+	// All three spellings, because the first version of MarshalJSON took a
+	// pointer receiver and only the first of these redacted. encoding/json
+	// does not invoke a pointer method for a non-addressable value, so the
+	// value and embedded forms fell back to reflection over the exported
+	// fields and emitted the whole cause — and the embedded form is precisely
+	// the log-sink case the method exists for.
+	spellings := map[string]any{
+		"pointer":  f,
+		"value":    *f,
+		"embedded": struct{ F fault.Fault }{*f},
+		"slice":    []fault.Fault{*f},
+	}
+	for name, subject := range spellings {
+		b, err := json.Marshal(subject)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", name, err)
+		}
+		for _, forbidden := range []string{"SECRET-KEY-9F2", "api.steampowered.com", "Cause", "cause"} {
+			if contains(string(b), forbidden) {
+				t.Fatalf("marshalling a Fault as a %s leaked %q: %s", name, forbidden, b)
+			}
+		}
+	}
+
 	b, err := json.Marshal(f)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	for _, forbidden := range []string{"SECRET-KEY-9F2", "api.steampowered.com", "Cause", "cause"} {
-		if contains(string(b), forbidden) {
-			t.Fatalf("marshalling a Fault leaked %q: %s", forbidden, b)
-		}
-	}
-
 	var got map[string]any
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -260,8 +278,12 @@ func TestMarshallingAFaultDropsTheCause(t *testing.T) {
 	if got["retry_after_seconds"] != float64(30) {
 		t.Fatalf("retry_after_seconds = %v; the one field a scripted caller acts on was dropped", got["retry_after_seconds"])
 	}
-	if _, err := json.Marshal((*fault.Fault)(nil)); err != nil {
+	nilBytes, err := json.Marshal((*fault.Fault)(nil))
+	if err != nil {
 		t.Fatalf("marshalling a nil Fault: %v", err)
+	}
+	if string(nilBytes) != "null" {
+		t.Fatalf("a nil Fault marshalled as %s, want null", nilBytes)
 	}
 }
 

--- a/internal/fault/keyshim.go
+++ b/internal/fault/keyshim.go
@@ -1,0 +1,17 @@
+package fault
+
+import "github.com/JustCode-CruzAlex/Zerado/internal/i18n"
+
+// messageOverride returns an Option that applies s only when it is non-empty,
+// so a caller can pass an unconditional override without first checking it.
+//
+// Outcome.MessageKey is a plain string rather than an i18n.Key so that a
+// provider package building an Outcome does not have to import i18n for one
+// field. The conversion is here, once.
+func messageOverride(s string) Option {
+	return func(f *Fault) {
+		if s != "" {
+			f.MessageKey = i18n.Key(s)
+		}
+	}
+}

--- a/internal/fault/kind.go
+++ b/internal/fault/kind.go
@@ -1,0 +1,225 @@
+// Package fault is Zerado's error taxonomy: one closed set of kinds, shared by
+// every seam, each one distinguishable by the caller because each one renders
+// differently on screen.
+//
+// # Why a taxonomy and not just errors
+//
+// The offline contract (07-offline-contract.md §5) classifies a failure into a
+// screen treatment, and the treatments are not interchangeable:
+//
+//	no route / DNS   → the OFFLINE banner        — nothing is wrong with anything
+//	timeout / 5xx    → the UNREACHABLE banner    — their end, not your key
+//	401 / 403        → a credential refusal      — your key, and it is fixable
+//	200 + zero items → a private-profile refusal — nothing is broken at all
+//
+// A private Steam profile is the case this package exists for. It is a
+// successful HTTP request, returning a well-formed empty body, from a service
+// that is up, using a key that works. Every mechanism that would collapse it
+// into "network error" — a bare error string, an HTTP status code, a boolean
+// ok — produces a screen that tells the player their connection failed when
+// their connection is fine, and sends them to debug the wrong thing. Worse,
+// 06-data-seams.md §2.4 requires that this exact case never tombstones a row:
+// a caller that cannot tell "the provider returned nothing" from "the provider
+// could not be reached" cannot honour that rule.
+//
+// # The two rules that keep it honest
+//
+//  1. A Fault carries an i18n.Key, never a sentence. ADR-0001 D9 forbids a
+//     user-facing string literal in code, and an error message is user-facing
+//     text. The Kind decides which key; the catalogue decides which words.
+//  2. A Fault's wrapped cause is for logs, never for a screen. It is where a
+//     URL with a query string — and therefore an API key — would otherwise
+//     reach a person's terminal. [Fault.Error] is a developer-facing string
+//     and is documented as never renderable.
+package fault
+
+// Kind is the closed set of ways an operation can fail in Zerado.
+//
+// The set is closed on purpose. A caller switching on Kind is writing the
+// screen treatment for every case the product has, and a new Kind is therefore
+// a design decision with a screen behind it — not a convenience for a package
+// that met an error it had not thought about. Anything genuinely unclassified
+// is [KindInternal], which renders as the fatal screen (Z-11) rather than as a
+// new species of banner.
+type Kind uint8
+
+const (
+	// KindUnknown is the zero value and is never valid.
+	//
+	// It is deliberately not "internal": a Fault built without a Kind is a
+	// construction bug, and giving the zero value a plausible meaning would
+	// let that bug ship as a screen nobody questions.
+	KindUnknown Kind = iota
+
+	// KindOffline means the machine could not begin the request: no route,
+	// or DNS did not resolve.
+	//
+	// This is the only Kind Zerado may report without having reached anyone,
+	// and it is still evidence-driven — 07 §5 forbids probing, so a request
+	// has to have been attempted and failed. Screen: the OFFLINE banner.
+	KindOffline
+
+	// KindUnreachable means the request was made and the far end did not
+	// usefully answer: a timeout, a 5xx, a connection reset mid-body.
+	//
+	// Distinct from KindOffline because the copy is different and the blame is
+	// different: "Steam didn't answer. Not your key — their end, or the
+	// connection."
+	KindUnreachable
+
+	// KindUnauthorized means the credential was rejected: 401, 403, or a
+	// provider's own equivalent.
+	//
+	// Distinct from KindUnreachable because it is the one network failure the
+	// player can actually fix, and the screen routes them to where they fix it.
+	KindUnauthorized
+
+	// KindRateLimited means the provider asked Zerado to slow down.
+	//
+	// It carries a RetryAfter whenever the provider supplied one. It is not
+	// KindUnreachable: the service is up, the key is good, and waiting works —
+	// which makes it the one failure a caller may retry without asking.
+	KindRateLimited
+
+	// KindEmpty means the provider answered successfully and returned nothing.
+	//
+	// For Steam this is the private-profile case (Z-03 state 11), and it is a
+	// refusal rather than an empty result set: 06 §2.4 and Z-03 §8.2 both
+	// forbid treating it as "the library was removed". No UpsertBatch, no
+	// tombstoning, and the copy may then truthfully say "Your library is
+	// unchanged — nothing was lost."
+	//
+	// Named for what was observed rather than for one provider's reason for
+	// it, because GOG and PlayStation will have their own reasons for the same
+	// observation and this Kind must survive them.
+	KindEmpty
+
+	// KindNotFound means the thing asked for does not exist at the source.
+	//
+	// On the metadata seam this is routine and is not a failure of anything:
+	// a hand-added cartridge that IGDB has never heard of produces
+	// KindNotFound, and the detail view renders the designed no-metadata
+	// composition (06 §3.1). On the store seam it is a real defect, because
+	// a screen asked for a GameID it was handed.
+	KindNotFound
+
+	// KindMalformed means the answer arrived and Zerado could not read it.
+	//
+	// Separated from KindUnreachable because the remedies are opposite: an
+	// unreachable provider is retried, a malformed answer is a provider whose
+	// contract changed and retrying it forever is how a client hammers an API
+	// that will never satisfy it.
+	KindMalformed
+
+	// KindStale means a cached value exists but is too old for the caller's
+	// purpose, and the caller declined to act on it.
+	//
+	// Zerado's read path never fetches (see the store seam), so staleness is
+	// normally shown rather than refused — a stale price renders with its age.
+	// This Kind is for the callers that must not act on an old value at all,
+	// the Phase 3 watchlist verdict being the case that motivated it: telling
+	// somebody to buy at a price from June is worse than telling them nothing.
+	KindStale
+
+	// KindUnsupported means the provider was asked to do something its
+	// Capabilities say it cannot.
+	//
+	// It should be nearly unreachable by construction — physical is not a
+	// Syncer, so there is no Sync to call — and that is the point: it is the
+	// backstop for a caller that switched on ProviderID instead of reading
+	// Capabilities, and it names that mistake instead of returning a plausible
+	// zero value.
+	KindUnsupported
+
+	// KindPrecondition means the operation is legal but the state is not ready
+	// for it.
+	//
+	// The load-bearing case is absence reconciliation: only a sync whose run
+	// status is ok may tombstone anything (06 §2.4), so a store asked to
+	// reconcile against a partial, failed or cancelled run must refuse rather
+	// than comply.
+	KindPrecondition
+
+	// KindConflict means the write collided with a uniqueness rule the store
+	// enforces — (provider_id, provider_ref) being the one Phase 1 has.
+	KindConflict
+
+	// KindCancelled means the player stopped it: Esc during a sync, q during a
+	// check, SIGINT at the CLI.
+	//
+	// It is never rendered as an error. Z-03's CANCELLED state has no cue, no
+	// red and no apology, because a cancelled sync did exactly what it was
+	// told and what arrived before the cancel is kept.
+	KindCancelled
+
+	// KindInternal is a defect in Zerado: a broken invariant, a corrupt
+	// database, a migration from a newer binary.
+	//
+	// It is the only Kind that is allowed to be vague to the player, because
+	// it is the only one where the honest answer is "this is ours". It routes
+	// to Z-11 Fatal error, which names both versions and stops.
+	KindInternal
+)
+
+// String returns the Kind's stable machine name.
+//
+// These names are API. They appear in the CLI's --json envelope and in logs,
+// so a script may switch on them; renaming one is a breaking change to the CLI
+// surface (see internal/cli). They are not messages and are never rendered to
+// a player — that is what MessageKey is for.
+func (k Kind) String() string {
+	switch k {
+	case KindOffline:
+		return "offline"
+	case KindUnreachable:
+		return "unreachable"
+	case KindUnauthorized:
+		return "unauthorized"
+	case KindRateLimited:
+		return "rate_limited"
+	case KindEmpty:
+		return "empty"
+	case KindNotFound:
+		return "not_found"
+	case KindMalformed:
+		return "malformed"
+	case KindStale:
+		return "stale"
+	case KindUnsupported:
+		return "unsupported"
+	case KindPrecondition:
+		return "precondition"
+	case KindConflict:
+		return "conflict"
+	case KindCancelled:
+		return "cancelled"
+	case KindInternal:
+		return "internal"
+	default:
+		return "unknown"
+	}
+}
+
+// Valid reports whether k is a member of the taxonomy.
+func (k Kind) Valid() bool { return k > KindUnknown && k <= KindInternal }
+
+// Retryable reports whether retrying the same operation unchanged could
+// plausibly succeed.
+//
+// It answers a question the CLI and the sync coordinator both have to ask, and
+// it is deliberately conservative: a Kind is retryable only when nothing has
+// to change first. KindUnauthorized is not retryable because the key is wrong
+// until the player changes it; KindEmpty is not, because the profile is
+// private until the player changes it; KindMalformed is not, because the
+// provider's contract moved and hammering it will not move it back.
+//
+// Retryable never means "retry automatically". Zerado retries when the player
+// presses r; this reports whether offering r is honest.
+func (k Kind) Retryable() bool {
+	switch k {
+	case KindOffline, KindUnreachable, KindRateLimited:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/fault/treatment.go
+++ b/internal/fault/treatment.go
@@ -54,7 +54,7 @@ const (
 // Treatment returns how this Kind is permitted to appear.
 //
 // The mapping is here, once, rather than in each screen, because the property
-// worth protecting is that the twelve Kinds do not silently converge on two
+// worth protecting is that the thirteen Kinds do not silently converge on two
 // treatments. A screen may choose different words; it may not choose a
 // different class.
 func (k Kind) Treatment() Treatment {

--- a/internal/fault/treatment.go
+++ b/internal/fault/treatment.go
@@ -1,0 +1,130 @@
+package fault
+
+import "github.com/JustCode-CruzAlex/Zerado/internal/i18n"
+
+// Treatment is how a Kind is allowed to appear on screen.
+//
+// It exists because "each Kind renders differently" is easy to assert and easy
+// to lose: a screen that has three failure paths and one error box will
+// quietly collapse the taxonomy back into a single treatment within a month.
+// Naming the treatment on the Kind makes the collapse visible in review and
+// testable in a table.
+//
+// It decides the *class* of presentation, never the composition. The design
+// system owns the banner (01-design-system.md §12) and each screen owns its
+// own refusal block; this only says which of them a given failure is entitled
+// to.
+type Treatment uint8
+
+const (
+	// TreatmentNone is for failures that are not shown as failures at all.
+	//
+	// KindCancelled is the whole membership: the player stopped it, the
+	// screen says what was kept, and nothing about that is an error.
+	TreatmentNone Treatment = iota
+
+	// TreatmentBanner is the degrade banner — one row at the top of the body,
+	// naming what is unavailable and how stale what is shown is.
+	//
+	// It is for ambient failure: something in the background could not be
+	// refreshed and the screen underneath is still completely usable.
+	TreatmentBanner
+
+	// TreatmentRefusal is a block on the screen the player is standing on,
+	// naming what happened, why, and the next action.
+	//
+	// It is for a failure of something the player just asked for. 07 §2 draws
+	// exactly this line: an action the player took is owed an answer, an
+	// ambient feature merely states its condition.
+	TreatmentRefusal
+
+	// TreatmentDesignedEmpty is not a failure presentation at all.
+	//
+	// KindNotFound on the metadata seam renders the designed no-metadata
+	// composition (06 §3.1). This is the difference between a product that
+	// works without IGDB and a product that is broken without IGDB, and it is
+	// recorded as a treatment so that "no metadata" can never be routed to an
+	// error banner by a well-meaning caller.
+	TreatmentDesignedEmpty
+
+	// TreatmentFatal is Z-11: the program cannot continue.
+	TreatmentFatal
+)
+
+// Treatment returns how this Kind is permitted to appear.
+//
+// The mapping is here, once, rather than in each screen, because the property
+// worth protecting is that the twelve Kinds do not silently converge on two
+// treatments. A screen may choose different words; it may not choose a
+// different class.
+func (k Kind) Treatment() Treatment {
+	switch k {
+	case KindCancelled:
+		return TreatmentNone
+	case KindOffline, KindUnreachable, KindStale, KindRateLimited:
+		return TreatmentBanner
+	case KindUnauthorized, KindEmpty, KindMalformed, KindPrecondition, KindConflict, KindUnsupported:
+		return TreatmentRefusal
+	case KindNotFound:
+		return TreatmentDesignedEmpty
+	default:
+		return TreatmentFatal
+	}
+}
+
+// MessageKey returns the catalogue key a Kind renders through by default.
+//
+// Providers override it through [WithMessage] when they have better copy for
+// their own case — Steam's private-profile refusal names a specific Steam
+// privacy setting, which no provider-agnostic KindEmpty entry could. The
+// default exists so that a provider which supplies no copy still renders a
+// sentence rather than a blank.
+//
+// The keys are subject-agnostic: the provider's name arrives as the {subject}
+// argument, which is what lets one entry serve Steam today and GOG later, in
+// every language, with no new key.
+func (k Kind) MessageKey() i18n.Key {
+	switch k {
+	case KindOffline:
+		return "fault.offline"
+	case KindUnreachable:
+		return "fault.unreachable"
+	case KindUnauthorized:
+		return "fault.unauthorized"
+	case KindRateLimited:
+		return "fault.rate_limited"
+	case KindEmpty:
+		return "fault.empty"
+	case KindNotFound:
+		return "fault.not_found"
+	case KindMalformed:
+		return "fault.malformed"
+	case KindStale:
+		return "fault.stale"
+	case KindUnsupported:
+		return "fault.unsupported"
+	case KindPrecondition:
+		return "fault.precondition"
+	case KindConflict:
+		return "fault.conflict"
+	case KindCancelled:
+		return "fault.cancelled"
+	default:
+		return "fault.internal"
+	}
+}
+
+// Kinds returns every member of the taxonomy, in declaration order.
+//
+// It exists so that a table-driven test can assert totality — that every Kind
+// has a name, a treatment, a key and an exit code — rather than asserting the
+// dozen cases somebody remembered. A new Kind then fails those tests until it
+// has been thought about everywhere, which is the enforcement this taxonomy
+// needs to still be a taxonomy in a year.
+func Kinds() []Kind {
+	return []Kind{
+		KindOffline, KindUnreachable, KindUnauthorized, KindRateLimited,
+		KindEmpty, KindNotFound, KindMalformed, KindStale, KindUnsupported,
+		KindPrecondition, KindConflict, KindCancelled, KindInternal,
+	}
+}

--- a/internal/fault/treatment.go
+++ b/internal/fault/treatment.go
@@ -116,15 +116,30 @@ func (k Kind) MessageKey() i18n.Key {
 
 // Kinds returns every member of the taxonomy, in declaration order.
 //
-// It exists so that a table-driven test can assert totality — that every Kind
-// has a name, a treatment, a key and an exit code — rather than asserting the
-// dozen cases somebody remembered. A new Kind then fails those tests until it
-// has been thought about everywhere, which is the enforcement this taxonomy
-// needs to still be a taxonomy in a year.
+// It is DERIVED from the iota range rather than hand-listed, and that is the
+// whole point of it.
+//
+// The first version of this function returned a literal slice. Every totality
+// test iterated that slice, and nothing asserted the slice covered the range —
+// so a Kind inserted mid-block was valid, constructible, and invisible to
+// every test that existed to catch exactly that. It silently claimed the
+// machine name "unknown" on a surface the CLI documents as stable API, and
+// rendered as TreatmentFatal with generic internal copy. CI stayed green.
+//
+// Deriving it removes the second source of truth instead of adding a test to
+// reconcile the two. [KindInternal] is the range's upper bound here and in
+// [Kind.Valid], so the two cannot disagree.
+//
+// The totality tests then have something real to iterate: TestTaxonomyIsTotal
+// asserts every kind has a distinct machine name, a treatment and a catalogue
+// key, and TestNoKindFallsThroughToTheDefaults asserts none of them silently
+// inherits the switch defaults. A new Kind fails both until it has been
+// thought about everywhere, which is the enforcement this taxonomy needs to
+// still be a taxonomy in a year.
 func Kinds() []Kind {
-	return []Kind{
-		KindOffline, KindUnreachable, KindUnauthorized, KindRateLimited,
-		KindEmpty, KindNotFound, KindMalformed, KindStale, KindUnsupported,
-		KindPrecondition, KindConflict, KindCancelled, KindInternal,
+	out := make([]Kind, 0, int(KindInternal))
+	for k := KindOffline; k <= KindInternal; k++ {
+		out = append(out, k)
 	}
+	return out
 }

--- a/internal/i18n/key.go
+++ b/internal/i18n/key.go
@@ -1,0 +1,60 @@
+// Package i18n carries the one type every other seam needs from the
+// catalogue: the key.
+//
+// ADR-0001 D9 is absolute — no user-facing string literal appears in code.
+// That rule has a consequence the seams have to obey rather than merely
+// respect: an error, a refusal, a banner label and a CLI message are all
+// user-facing text, so none of them may be an English sentence held in a
+// struct field. What the seams carry is a Key; what turns a Key into words
+// is the catalogue, and the catalogue is a rendering concern that lives
+// above every seam in this module.
+//
+// This package therefore deliberately contains no strings, no catalogue and
+// no renderer. It contains the type that makes the rule enforceable at the
+// boundary, which is all a contracts package can honestly own.
+package i18n
+
+// Key names one entry in the message catalogue.
+//
+// Keys are dot-separated, lowercase, and read subject-first so that the
+// catalogue sorts into the shape of the product:
+//
+//	fault.steam.key_rejected
+//	fault.steam.profile_private
+//	sync.done.headline
+//	settings.vault.backing.keychain
+//
+// A Key is not text. It is never rendered, compared for display, lowercased,
+// or concatenated with another Key. Two catalogues may render the same Key
+// into different languages, and that is the entire point.
+//
+// The empty Key is invalid. A value that reaches a renderer with an empty Key
+// is a programming error, not a blank message: see [Key.Valid].
+type Key string
+
+// Valid reports whether k could name a catalogue entry.
+//
+// It is a shape check, not a lookup — this package does not know which keys
+// exist. The catalogue's own loader owns "this key is missing", because that
+// is a build-time failure under D9's lint rather than a runtime state.
+func (k Key) Valid() bool { return k != "" }
+
+// String returns the key itself, for logs and test failures.
+//
+// It is spelled out rather than left to Go's default formatting so that a Key
+// reaching a log looks like a key and not like a message someone forgot to
+// translate.
+func (k Key) String() string { return string(k) }
+
+// Args carries the substitutions a message needs.
+//
+// Named rather than positional, because a translator reordering a sentence is
+// the normal case and a positional verb makes that reordering a code change.
+// Values are formatted by the catalogue with locale-aware number, currency and
+// date rules (golang.org/x/text), so callers pass the value — an int, a
+// time.Time, a Money — and never a pre-formatted string.
+//
+// A pre-formatted string in Args is the most common way D9 is violated while
+// appearing to be obeyed: the literal moves out of the render call and into
+// the argument, and the lint no longer sees it.
+type Args map[string]any

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -1,0 +1,161 @@
+// Package images is the terminal-image seam. A screen asks for a cover at a
+// size; it never learns which protocol answered, or whether one did.
+//
+// ADR-0001 D8 makes cover art foundational rather than an enhancement — "a
+// game library without cover art is a spreadsheet" — and makes a terminal
+// without image support a *supported configuration* rather than a warning
+// state. Both halves of that are in this interface: [Images.Cover] answers for
+// any terminal, and [Capability] is the only place the protocol is named.
+//
+// # Two properties carry the whole design
+//
+// Cover never blocks and never fetches. The render path reads what is already
+// present; a cover the cache does not hold is simply not shown this frame.
+// This is the same rule as audio's Cue and for the same reason: a missing
+// cover is never worth a dropped frame.
+//
+// A screen never learns the protocol. Adding Sixel later, or dropping iTerm2,
+// changes one implementation and no screen.
+package images
+
+import (
+	"context"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+)
+
+// Images is the whole surface.
+type Images interface {
+	// Capability reports what this terminal can draw.
+	//
+	// Resolved once at start-up and cached for the session, never a config
+	// flag the player has to find. Detection must fail closed: an ambiguous
+	// or timed-out response means no image support, because guessing yes and
+	// emitting escape sequences into a terminal that does not understand them
+	// is how a library view turns into garbage on somebody's screen.
+	Capability() Capability
+
+	// Cover returns a placement for an already-cached image.
+	//
+	// It never fetches, never blocks and never returns an error. ok=false
+	// means "not this frame", which the caller renders as the designed
+	// no-cover tile — never a broken-image box, and never a spinner, because
+	// there is nothing to wait for on this path.
+	//
+	// It takes no context, and that is the signature carrying the guarantee:
+	// a function that cannot block has nothing to cancel, and a ctx parameter
+	// here would be an invitation to make it blocking later.
+	Cover(id library.GameID, cells Rect) (Placement, bool)
+
+	// Warm asks the cache to fetch, off the render path, best-effort.
+	//
+	// It is the only method that touches the network, and it returns
+	// immediately. ids is the set worth having soon — the visible tiles plus
+	// a little ahead of the viewport, never the whole library, because
+	// warming 247 covers to show 12 is how terminal images come to feel slow.
+	//
+	// Fetching is one owned worker pool bounded by ctx. The seam owns it; no
+	// screen ever starts a goroutine for this.
+	Warm(ctx context.Context, ids []library.GameID, cells Rect)
+
+	// Forget drops a cached image, for the Settings action that clears the
+	// cache. Deleting the whole cache must cost nothing but bandwidth.
+	Forget(id library.GameID)
+
+	// Close stops the worker pool and releases the cache handle.
+	Close() error
+}
+
+// Capability is what the terminal can draw.
+type Capability uint8
+
+const (
+	// CapabilityNone is a terminal that cannot draw images, or one where
+	// detection was ambiguous, or where ZERADO_NO_IMAGES is set.
+	//
+	// It is a supported configuration. The full text deck renders, and the
+	// player is told once, quietly and dismissibly, that Ghostty or Kitty
+	// would show covers — never recurring, never blocking, and never phrased
+	// as a fault in their setup.
+	CapabilityNone Capability = iota
+
+	// CapabilityKitty is the Kitty graphics protocol: Kitty, Ghostty,
+	// WezTerm, Konsole.
+	CapabilityKitty
+
+	// CapabilityITerm2 is iTerm2's inline-image protocol.
+	CapabilityITerm2
+)
+
+// String returns the stable machine name. Z-09 renders these through the
+// catalogue; the CLI's JSON emits them directly.
+func (c Capability) String() string {
+	switch c {
+	case CapabilityKitty:
+		return "kitty"
+	case CapabilityITerm2:
+		return "iterm2"
+	default:
+		return "none"
+	}
+}
+
+// Draws reports whether this capability can place an image at all.
+func (c Capability) Draws() bool { return c != CapabilityNone }
+
+// Rect is a size in terminal cells, not pixels.
+//
+// Cells because every layout decision in this product is made in cells, and a
+// pixel size here would force each screen to know its terminal's cell
+// geometry — which is the one measurement a terminal program cannot reliably
+// obtain.
+type Rect struct{ Cols, Rows int }
+
+// Placement is an opaque instruction to draw an image at a position.
+//
+// It carries the escape sequence and the footprint, and a screen composes it
+// into its frame without interpreting it. Opaque on purpose: the day Sixel is
+// added, a screen that had been reading these bytes would be a screen that
+// needs changing.
+type Placement struct {
+	// Sequence is the terminal control sequence that draws the image.
+	Sequence string
+
+	// Cells is the footprint the sequence will occupy, so the layout can
+	// reserve exactly that much and the rest of the row still adds up.
+	Cells Rect
+
+	// ID is the transmitted image's identity in the terminal's own image
+	// table, where the protocol has one.
+	//
+	// Present because re-sending image data every frame is the failure mode
+	// that makes terminal images feel slow: Kitty placements are addressed by
+	// image id, so an image is transmitted once and placed many times.
+	ID uint32
+}
+
+// Null is the images implementation that draws nothing.
+//
+// It is what runs when detection fails, in tests, and under ZERADO_NO_IMAGES —
+// so the text path is the well-exercised one rather than an untested fallback.
+// It lives in this package rather than in a test helper for that reason: it is
+// production code that a large share of users will actually run.
+type Null struct{}
+
+// Capability reports that nothing can be drawn.
+func (Null) Capability() Capability { return CapabilityNone }
+
+// Cover always declines, which renders the designed no-cover tile.
+func (Null) Cover(library.GameID, Rect) (Placement, bool) { return Placement{}, false }
+
+// Warm does nothing. It notably does not fetch: a build that cannot draw an
+// image has no reason to spend the player's bandwidth on one.
+func (Null) Warm(context.Context, []library.GameID, Rect) {}
+
+// Forget does nothing.
+func (Null) Forget(library.GameID) {}
+
+// Close does nothing and cannot fail.
+func (Null) Close() error { return nil }
+
+var _ Images = Null{}

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -1,0 +1,58 @@
+package images_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/images"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+)
+
+// TestATerminalWithoutImagesIsSupported, not warned at. The text deck renders
+// and the player is told once, quietly. Null is the implementation a large
+// share of users will actually run, which is why it lives in the production
+// package rather than in a test helper.
+func TestATerminalWithoutImagesIsSupported(t *testing.T) {
+	var im images.Images = images.Null{}
+	if im.Capability().Draws() {
+		t.Fatal("Null claims it can draw")
+	}
+	if _, ok := im.Cover(library.GameID(1), images.Rect{Cols: 17, Rows: 6}); ok {
+		t.Fatal("Null returned a placement")
+	}
+	if err := im.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// TestCoverCannotBlockAndCannotFail is the signature carrying the guarantee: a
+// function with no context has nothing to cancel, and one with no error return
+// cannot be waited on. A missing cover is never worth a dropped frame.
+func TestCoverCannotBlockAndCannotFail(t *testing.T) {
+	// Cover takes no context and returns no error. If either changed, this
+	// assignment would stop compiling — which is the test.
+	var cover func(library.GameID, images.Rect) (images.Placement, bool) = images.Null{}.Cover
+	if _, ok := cover(1, images.Rect{}); ok {
+		t.Fatal("Null answered a cover")
+	}
+}
+
+// TestWarmIsTheOnlyThingThatTouchesTheNetwork, and a build that cannot draw
+// has no reason to spend the player's bandwidth.
+func TestWarmIsTheOnlyThingThatTouchesTheNetwork(t *testing.T) {
+	images.Null{}.Warm(context.Background(), []library.GameID{1, 2, 3}, images.Rect{Cols: 17, Rows: 6})
+}
+
+// TestCapabilityNamesAreStable: Z-09 renders them through the catalogue and
+// the CLI's JSON emits them directly.
+func TestCapabilityNamesAreStable(t *testing.T) {
+	for c, want := range map[images.Capability]string{
+		images.CapabilityNone:   "none",
+		images.CapabilityKitty:  "kitty",
+		images.CapabilityITerm2: "iterm2",
+	} {
+		if got := c.String(); got != want {
+			t.Fatalf("Capability(%d).String() = %q, want %q", c, got, want)
+		}
+	}
+}

--- a/internal/library/game.go
+++ b/internal/library/game.go
@@ -1,0 +1,163 @@
+// Package library holds the domain types the screens read: the game as Zerado
+// stores it, the query that selects games, and the identity that will let two
+// devices merge in Phase 4.
+//
+// It sits above the provider seam and below the store seam. A provider
+// produces provider.Item; the store turns Items into Games; a screen reads
+// Games and nothing else. Nothing in this package does I/O, and that is what
+// makes every Phase 1 screen testable with no network and no database.
+//
+// # Zerado is a games product, and this package is a games model
+//
+// ADR-0001 D5 pruned the media-polymorphic core and it is worth restating what
+// that means at the interface layer, because the ticket asks for
+// "media-type polymorphism at the interface layer" and the ratified answer is
+// that there must not be any. 06-data-seams.md §7 names a media-type
+// abstraction as explicitly not a seam: "an interface parameterised on a type
+// that has one value is machinery without a purpose."
+//
+// The door is held open by two things and neither of them is a type
+// parameter: the stored entity is called item rather than games, and it
+// carries an item_type constrained to 'game'. That is the whole affordance,
+// it costs two columns, and it is why the Go type here is [Game] with no
+// generic parameter and no MediaType field. See
+// docs/api/06-divergences-from-the-spine.md for the reconciliation with the
+// ticket's wording.
+package library
+
+import (
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// GameID is the local surrogate key.
+//
+// It is local: it identifies a row in this machine's file and it means nothing
+// on another device. Phase 4 merges on [UID] instead, which is exactly why the
+// two are different types rather than two int64s that would eventually be
+// passed to each other's functions.
+type GameID int64
+
+// UID is the stable, content-derived cross-device identity.
+//
+// It is a merge *hint*, never an authority. 06-data-seams.md §6.2 derives it
+// as uuidv5 over a normalised title and platform, and is explicit that the
+// normalisation is imperfect — two editions may collide, the same game may
+// fail to match across platforms — so Phase 4 presents ambiguous matches to
+// the player rather than guessing, and (provider_id, provider_ref) remains the
+// unique constraint while this is merely indexed.
+//
+// Assigned at insert and never changed. Adding it in Phase 1 costs one column
+// and one index; adding it in Phase 4 would cost a migration that has to
+// invent stable identities for rows whose titles the player has since edited.
+//
+// The exact normalisation rules are fft-database's, against a real library's
+// titles (13-handoffs.md §4). This type carries the policy, not the algorithm.
+type UID string
+
+// Game is one row of the library, as the screens see it.
+//
+// Its optional fields are pointers for the reason given on provider.Item:
+// "not tracked", "not fetched yet" and "known to be nothing" are three facts,
+// and Z-05 renders all three differently.
+type Game struct {
+	// ID is the local key. UID is the cross-device hint.
+	ID  GameID
+	UID UID
+
+	// Provider is where this row came from. It is stored, and it is read for
+	// exactly two purposes: looking the provider up in a registry, and
+	// rendering the SOURCE row. Any third use is the switch on identity that
+	// Capabilities exists to replace.
+	Provider    provider.ID
+	ProviderRef string
+
+	Title    string
+	Platform string
+
+	// SortTitle is the collation key — articles stripped, diacritics folded.
+	//
+	// It is stored rather than computed on read because Phase 1's only order
+	// is title A→Z (07 §2) and the alternative is a full-table sort in Go on
+	// every keystroke of a filter. fft-database owns its exact derivation.
+	SortTitle string
+
+	// PlaytimeMinutes is provider-reported; nil means not reported.
+	PlaytimeMinutes *int
+
+	// LastPlayed is provider-reported; nil means not reported, which is not
+	// the same as never played.
+	LastPlayed *time.Time
+
+	// OwnedSince is when the player acquired it, where knowable.
+	OwnedSince *time.Time
+
+	// AddedAt is when Zerado first saw this row. Always known, because Zerado
+	// is the one that wrote it.
+	AddedAt time.Time
+
+	// StatusManual is the player's explicit choice, or nil when they have
+	// never expressed one.
+	//
+	// A sync never writes this field. That is the invariant that makes the
+	// product trustworthy: mark a game ZERADO, play three more hours, and the
+	// next sync updates playtime and last-played and nothing else.
+	StatusManual *status.Status
+
+	// StatusChangedAt is when StatusManual last changed, and nil when it never
+	// has.
+	//
+	// It is the timestamp that decides a Phase 4 conflict — last-write-wins
+	// per game — and it is in Phase 1's schema for that reason alone, which
+	// 05-state-machine.md §8 names as the expensive decision made early.
+	StatusChangedAt *time.Time
+
+	// AbsentSince is set when a complete, successful sync stopped returning
+	// this game, and cleared the moment it comes back.
+	//
+	// It is not a fifth state. It is an orthogonal presence flag, and the row
+	// still has a status — usually the most valuable one, because a game you
+	// finished and no longer own is exactly the row you would be angriest to
+	// lose. Absent rows are excluded from the default view, remain findable by
+	// filter, and are never deleted as a consequence of a sync.
+	AbsentSince *time.Time
+
+	// MergedInto points at the row this one was merged into, in Phase 4.
+	//
+	// Present in the Phase 1 type because the column is present in the Phase 1
+	// schema, so that a merge never has to rewrite primary keys. Nothing in
+	// Phase 1 sets it and every Phase 1 query excludes rows that have it.
+	MergedInto *GameID
+}
+
+// Absent reports whether a sync has stopped returning this game.
+func (g Game) Absent() bool { return g.AbsentSince != nil }
+
+// Playtime returns the reported playtime and whether it was reported.
+func (g Game) Playtime() (int, bool) {
+	if g.PlaytimeMinutes == nil {
+		return 0, false
+	}
+	return *g.PlaytimeMinutes, true
+}
+
+// Status returns the effective status: the manual value if the player set one,
+// otherwise the derivation.
+//
+// canReportPlaytime is the provider's Capabilities.Playtime. It is a parameter
+// rather than a field because a capability is a property of the provider and
+// storing a copy of it on every row would be a second, stale writer of a fact
+// the registry already holds — the same argument that keeps effective_status
+// out of the schema.
+func (g Game) Status(canReportPlaytime bool) status.Status {
+	pt, _ := g.Playtime()
+	return status.Effective(g.StatusManual, pt, canReportPlaytime)
+}
+
+// Overridden reports whether the player has set a manual status.
+//
+// Z-06 shows a fifth item — "clear override" — only when this is true, and
+// Z-05 shows the SET BY and <PROVIDER> SAYS rows only when it is true.
+func (g Game) Overridden() bool { return g.StatusManual != nil }

--- a/internal/library/game.go
+++ b/internal/library/game.go
@@ -21,7 +21,7 @@
 // carries an item_type constrained to 'game'. That is the whole affordance,
 // it costs two columns, and it is why the Go type here is [Game] with no
 // generic parameter and no MediaType field. See
-// docs/api/06-divergences-from-the-spine.md for the reconciliation with the
+// docs/api/06-divergences.md for the reconciliation with the
 // ticket's wording.
 package library
 

--- a/internal/library/query.go
+++ b/internal/library/query.go
@@ -1,0 +1,123 @@
+package library
+
+import (
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// Query selects a subset of the library.
+//
+// It is the shape Z-07's filter bar produces and the shape the store consumes,
+// and it exists as a value type so that "the summary describes the filtered
+// set" (05-state-machine.md §7 rule 2) is enforceable: the same Query goes to
+// [store.Store.Games] and to [store.Store.Counts], so the list and the numbers
+// above it cannot describe different sets.
+//
+// # Why this and not a generic CRUD surface
+//
+// The ticket asks for the query shapes the interface actually needs rather
+// than a generic surface, and this is the whole of it. Phase 1 has exactly
+// three facets — a search, a set of states, a set of sources — plus a presence
+// mode. There is no builder, no expression tree and no operator: a filter
+// language would be an abstraction with one consumer, and the consumer is a
+// filter bar with three chips.
+//
+// # There is no sort field, and that is a decision
+//
+// 07-offline-contract.md §2 fixes Phase 1's order at title A→Z with no sort
+// control, and is explicit that an on-screen sort indicator would imply a
+// control that does not exist. A Sort field here would be that indicator's
+// back end: present, unused, and the obvious thing to wire up. It is left out
+// so that adding sorting is a deliberate act with a screen behind it.
+type Query struct {
+	// Search is the free-text facet. Empty matches everything.
+	//
+	// Matching is the store's — a case-folding, diacritic-folding substring
+	// match over the title, which is what SortTitle exists for. It is not
+	// specified further here because it is a SQL detail (fft-database's), and
+	// because the one property a screen depends on is that an empty query
+	// filters nothing (Z-07 F2).
+	Search string
+
+	// States restricts to these effective statuses. Empty means all four.
+	//
+	// Effective, not manual: a player filtering for IN PROGRESS means the
+	// games that are in progress, including the ones that are in progress
+	// because Steam said so.
+	States []status.Status
+
+	// Sources restricts to these providers. Empty means all.
+	Sources []provider.ID
+
+	// Presence decides whether absent rows are included, excluded, or the
+	// only thing shown.
+	Presence Presence
+
+	// Limit and Offset page the result. Zero Limit means no limit.
+	//
+	// Present because Z-04 renders twelve rows of a 247-row library at 80×24
+	// and reading all 247 to show 12 is a habit that stops being free at
+	// 10,000. The screen's scroll position row — "ROWS 4–15 of 247" — needs
+	// the total as well, which is why [store.Store.Counts] takes the same
+	// Query and is not merely a convenience over Games.
+	Limit  int
+	Offset int
+}
+
+// Presence is the absent-row mode of a query.
+//
+// Absence is not a fifth state (06-data-seams.md §2.4), so it is not a member
+// of States. It is an orthogonal axis, and modelling it as one is what lets
+// Z-07's ABSENT chip swap the row set and then filter by state *within* it.
+type Presence uint8
+
+const (
+	// PresentOnly excludes absent rows. This is the default, and it is the
+	// default library view.
+	PresentOnly Presence = iota
+
+	// AbsentOnly returns only absent rows — Z-07's ABSENT facet, which is how
+	// 06 §2.4's promise that absent rows "remain findable by filter" is kept.
+	AbsentOnly
+
+	// Either includes both, for the CLI's --all and for a Phase 4 merge that
+	// must see everything.
+	Either
+)
+
+// Empty reports whether the query filters nothing.
+//
+// Z-07 F2 requires that an empty editor filters nothing and shows the full
+// ratio, and Z-04's unfiltered summary is the same predicate read the other
+// way: a summary says "247 games" without naming a filter exactly when this is
+// true. Paging is not a filter, so Limit and Offset are not consulted.
+func (q Query) Empty() bool {
+	return q.Search == "" &&
+		len(q.States) == 0 &&
+		len(q.Sources) == 0 &&
+		q.Presence == PresentOnly
+}
+
+// Facets returns the names of the active facets, in the order Z-07 renders
+// them.
+//
+// It exists for the empty-result line, which must name the facet that emptied
+// the set rather than apologising — "search was fine, the state filter emptied
+// it". Names are stable machine tokens; the screen renders them through the
+// catalogue.
+func (q Query) Facets() []string {
+	var out []string
+	if q.Search != "" {
+		out = append(out, "search")
+	}
+	if len(q.States) > 0 {
+		out = append(out, "state")
+	}
+	if len(q.Sources) > 0 {
+		out = append(out, "source")
+	}
+	if q.Presence == AbsentOnly {
+		out = append(out, "absent")
+	}
+	return out
+}

--- a/internal/library/query.go
+++ b/internal/library/query.go
@@ -85,12 +85,34 @@ const (
 	Either
 )
 
-// Empty reports whether the query filters nothing.
+// Empty reports whether the query describes the default library view.
 //
 // Z-07 F2 requires that an empty editor filters nothing and shows the full
 // ratio, and Z-04's unfiltered summary is the same predicate read the other
 // way: a summary says "247 games" without naming a filter exactly when this is
 // true. Paging is not a filter, so Limit and Offset are not consulted.
+//
+// # Why [Either] counts as not-empty, even though it narrows nothing
+//
+// Either is *less* restrictive than the PresentOnly default: it adds absent
+// rows rather than removing anything. So "filters nothing" is arguably true of
+// it, and an earlier revision returned false here while [Query.Facets]
+// returned nothing at all — leaving the contract's own idiom,
+//
+//	if !q.Empty() { name(q.Facets()[0]) }
+//
+// indexing an empty slice.
+//
+// The resolution is that this predicate is not really about narrowing. It is
+// about whether the summary must say which set it is describing, and a set
+// that includes absent rows is emphatically not the default view: its count
+// differs from Z-04's, and showing the larger number under an unqualified
+// "247 games" is the same lie §7 rule 2 forbids for a state filter.
+//
+// So Either is not-empty, and Facets names it. The invariant the two now hold
+// together — !Empty() implies at least one facet — is asserted over the whole
+// cross-product by TestEmptyAndFacetsAgree, because the defect was not the
+// missing case but the absence of anything tying the pair together.
 func (q Query) Empty() bool {
 	return q.Search == "" &&
 		len(q.States) == 0 &&
@@ -116,8 +138,15 @@ func (q Query) Facets() []string {
 	if len(q.Sources) > 0 {
 		out = append(out, "source")
 	}
-	if q.Presence == AbsentOnly {
+	switch q.Presence {
+	case AbsentOnly:
 		out = append(out, "absent")
+	case Either:
+		// Named separately from "absent" because they describe different sets
+		// and a player needs to be able to tell which one they are looking at:
+		// one is only the rows a sync stopped returning, the other is
+		// everything including them. It matches the CLI's --all.
+		out = append(out, "all")
 	}
 	return out
 }

--- a/internal/library/query_test.go
+++ b/internal/library/query_test.go
@@ -129,3 +129,74 @@ func TestOverriddenDrivesTheFifthMenuItem(t *testing.T) {
 		t.Fatal("a game with no manual status reports itself overridden; Z-06 would offer to clear nothing")
 	}
 }
+
+// TestEmptyAndFacetsAgree is the MINOR-1 repair from the review at 4484d9a,
+// and it is deliberately a property over the whole cross-product rather than a
+// case for the value that was wrong.
+//
+// Empty and Facets are a pair: Empty decides whether the summary names a
+// filter at all, Facets names which one emptied the set. The contract's own
+// idiom is
+//
+//	if !q.Empty() { name(q.Facets()[0]) }
+//
+// so a query that reports itself filtered while naming no facet indexes an
+// empty slice. Query{Presence: Either} did exactly that, and neither existing
+// test reached it — one iterated the other three dimensions, the other built a
+// single all-facets query.
+//
+// The defect was not the missing case. It was that nothing tied the two
+// functions together, so any future dimension can reintroduce it. This asserts
+// the relationship instead, which a new facet cannot slip past.
+func TestEmptyAndFacetsAgree(t *testing.T) {
+	searches := []string{"", "souls"}
+	stateSets := [][]status.Status{nil, {status.Zerado}}
+	sourceSets := [][]provider.ID{nil, {"physical"}}
+	presences := []library.Presence{library.PresentOnly, library.AbsentOnly, library.Either}
+
+	var checked int
+	for _, search := range searches {
+		for _, states := range stateSets {
+			for _, sources := range sourceSets {
+				for _, presence := range presences {
+					for _, limit := range []int{0, 12} {
+						q := library.Query{
+							Search: search, States: states, Sources: sources,
+							Presence: presence, Limit: limit,
+						}
+						checked++
+						facets := q.Facets()
+						switch {
+						case q.Empty() && len(facets) != 0:
+							t.Fatalf("%+v reports itself unfiltered but names facets %v", q, facets)
+						case !q.Empty() && len(facets) == 0:
+							t.Fatalf("%+v reports itself filtered but names no facet; "+
+								"the contract's own idiom indexes an empty slice here", q)
+						}
+					}
+				}
+			}
+		}
+	}
+	if checked != len(searches)*len(stateSets)*len(sourceSets)*len(presences)*2 {
+		t.Fatalf("the cross-product walked %d combinations; the loops are wrong", checked)
+	}
+}
+
+// TestEitherAndAbsentAreDifferentSets: a player must be able to tell which of
+// the two they are looking at — one is only the rows a sync stopped returning,
+// the other is everything including them.
+func TestEitherAndAbsentAreDifferentSets(t *testing.T) {
+	absent := library.Query{Presence: library.AbsentOnly}.Facets()
+	all := library.Query{Presence: library.Either}.Facets()
+
+	if len(absent) != 1 || absent[0] != "absent" {
+		t.Fatalf("AbsentOnly facets = %v", absent)
+	}
+	if len(all) != 1 || all[0] != "all" {
+		t.Fatalf("Either facets = %v", all)
+	}
+	if absent[0] == all[0] {
+		t.Fatal("the two presence modes name the same facet; the summary could not say which set it describes")
+	}
+}

--- a/internal/library/query_test.go
+++ b/internal/library/query_test.go
@@ -1,0 +1,131 @@
+package library_test
+
+import (
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// TestAnEmptyQueryFiltersNothing is Z-07 F2: the editor opens showing "247 of
+// 247" and the list is unchanged.
+func TestAnEmptyQueryFiltersNothing(t *testing.T) {
+	if !(library.Query{}).Empty() {
+		t.Fatal("the zero Query reports itself as filtering something")
+	}
+	if !(library.Query{Limit: 12, Offset: 24}).Empty() {
+		t.Fatal("paging counted as a filter; the summary would then claim a filter that does not exist")
+	}
+	for _, q := range []library.Query{
+		{Search: "souls"},
+		{States: []status.Status{status.Zerado}},
+		{Sources: []provider.ID{"physical"}},
+		{Presence: library.AbsentOnly},
+	} {
+		if q.Empty() {
+			t.Fatalf("%+v reported itself empty", q)
+		}
+	}
+}
+
+// TestFacetsNameWhatEmptiedTheSet: an empty result names the filter that
+// emptied it rather than apologising — "search was fine, the state filter
+// emptied it."
+func TestFacetsNameWhatEmptiedTheSet(t *testing.T) {
+	q := library.Query{
+		Search:   "souls",
+		States:   []status.Status{status.Zerado},
+		Sources:  []provider.ID{"steam"},
+		Presence: library.AbsentOnly,
+	}
+	got := q.Facets()
+	want := []string{"search", "state", "source", "absent"}
+	if len(got) != len(want) {
+		t.Fatalf("Facets = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Facets = %v, want %v (order is the order Z-07 renders them)", got, want)
+		}
+	}
+	if len((library.Query{}).Facets()) != 0 {
+		t.Fatal("an unfiltered query named a facet")
+	}
+}
+
+// TestAbsenceIsNotAState: the four states are ratified and CVD-verified, and
+// an absent game still has one — usually the most valuable one.
+func TestAbsenceIsNotAState(t *testing.T) {
+	for _, s := range status.All() {
+		if int(s) > 4 {
+			t.Fatalf("a fifth state exists: %v", s)
+		}
+	}
+	// Presence is a separate axis, which is what lets the ABSENT facet swap
+	// the row set and then filter by state within it.
+	q := library.Query{Presence: library.AbsentOnly, States: []status.Status{status.Zerado}}
+	if len(q.Facets()) != 2 {
+		t.Fatalf("state and presence did not compose: %v", q.Facets())
+	}
+}
+
+// TestGameDistinguishesThreeFactsAboutPlaytime is what Z-05 renders as "not
+// tracked", "—" and "0h". Collapsing any two produces a screen that tells a
+// player their cartridge has been played for zero hours.
+func TestGameDistinguishesThreeFactsAboutPlaytime(t *testing.T) {
+	zero := 0
+
+	notTracked := library.Game{Provider: "physical"}
+	if _, reported := notTracked.Playtime(); reported {
+		t.Fatal("a cartridge reported a playtime")
+	}
+	if got := notTracked.Status(false); got != status.NotStarted {
+		t.Fatalf("a cartridge derived to %v", got)
+	}
+
+	notFetched := library.Game{Provider: "steam"}
+	if _, reported := notFetched.Playtime(); reported {
+		t.Fatal("an unfetched row reported a playtime")
+	}
+
+	knownEmpty := library.Game{Provider: "steam", PlaytimeMinutes: &zero}
+	pt, reported := knownEmpty.Playtime()
+	if !reported || pt != 0 {
+		t.Fatalf("a known-zero playtime read as %d, %v; zero is a real value", pt, reported)
+	}
+	if knownEmpty.Status(true) != status.NotStarted {
+		t.Fatal("a known-zero playtime did not derive to NOT STARTED")
+	}
+}
+
+// TestRefIsAnswerableForACartridge is the shape test for the enrichment
+// seams: a ref whose primary key were a store identifier would be unanswerable
+// for a shelf, which is the majority case for a shelf.
+func TestRefIsAnswerableForACartridge(t *testing.T) {
+	cartridge := library.Ref{Title: "Chrono Trigger", Platform: "SNES"}
+	if !cartridge.Identifiable() {
+		t.Fatal("a title and a platform are not enough to ask a source about a game")
+	}
+	if (library.Ref{Provider: "steam", ProviderRef: "1086940"}).Identifiable() {
+		t.Fatal("a ref with only store identifiers passed; a source that does not know Steam could not use it")
+	}
+
+	g := library.Game{Title: "Hades", Platform: "PC", Provider: "steam", ProviderRef: "1145360"}
+	r := library.RefOf(g)
+	if r.Title != g.Title || r.Platform != g.Platform || r.ProviderRef != g.ProviderRef {
+		t.Fatalf("RefOf lost a field: %+v", r)
+	}
+}
+
+// TestOverriddenDrivesTheFifthMenuItem: Z-06 shows "clear override" only when
+// there is one to clear.
+func TestOverriddenDrivesTheFifthMenuItem(t *testing.T) {
+	z := status.Zerado
+	if !(library.Game{StatusManual: &z}).Overridden() {
+		t.Fatal("a game with a manual status does not report itself overridden")
+	}
+	if (library.Game{}).Overridden() {
+		t.Fatal("a game with no manual status reports itself overridden; Z-06 would offer to clear nothing")
+	}
+}

--- a/internal/library/ref.go
+++ b/internal/library/ref.go
@@ -1,0 +1,55 @@
+package library
+
+import "github.com/JustCode-CruzAlex/Zerado/internal/provider"
+
+// Ref is enough to identify a game to an outside source, without assuming
+// that source knows anything about stores.
+//
+// It is what the metadata and price seams take. Both of them are asked about
+// games that may have arrived from Steam, from a shelf, or from a store that
+// does not exist yet, so the ref carries what every source can use — a title
+// and a platform — plus the store identifiers a source may use if it happens
+// to recognise them.
+//
+// The ordering matters. A ref whose primary key were the Steam appid would
+// work beautifully and would be unanswerable for a cartridge, which is the
+// majority case for a shelf. Title and platform are the fields that are always
+// present because [Game] requires both; everything else is a bonus a source is
+// free to ignore.
+type Ref struct {
+	// Title and Platform are always present.
+	Title    string
+	Platform string
+
+	// Provider and ProviderRef are the store's own identifiers, when the game
+	// came from a store.
+	//
+	// A metadata source that recognises Steam appids gets a far better match
+	// from these than from a title. A source that does not, ignores them. What
+	// neither may do is require them, which is what makes this seam answerable
+	// for a cartridge.
+	Provider    provider.ID
+	ProviderRef string
+
+	// Extra carries additional identifiers a provider emitted — the same
+	// narrow escape hatch as provider.Item.Extra, and under the same rule: a
+	// key is read only by a source that recognises it, never by a screen.
+	Extra map[string]string
+}
+
+// RefOf builds a Ref from a stored game.
+func RefOf(g Game) Ref {
+	return Ref{
+		Title:       g.Title,
+		Platform:    g.Platform,
+		Provider:    g.Provider,
+		ProviderRef: g.ProviderRef,
+	}
+}
+
+// Identifiable reports whether this ref carries enough to ask anyone about.
+//
+// Title and platform are the floor. A ref without them is a bug in the caller,
+// and a source asked with one should return fault.KindMalformed rather than a
+// guess.
+func (r Ref) Identifiable() bool { return r.Title != "" && r.Platform != "" }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,0 +1,181 @@
+// Package metadata is the enrichment seam: cover art, sinopse, genres and
+// release data, from a source Zerado deliberately does not name in its own
+// types.
+//
+// # The seam is a hedge, and the hedge outlived its original reason
+//
+// It was designed when IGDB's free-for-non-commercial terms sat badly against
+// an affiliate-funded product. Founder direction on 2026-08-25 dropped
+// affiliate links entirely, so Zerado is cleanly non-commercial — free
+// software, donation-supported, zero revenue — and IGDB's published test,
+// whether the project generates revenue, is now answered.
+//
+// That reading is a reading of a published rationale and not a guarantee: a
+// direct confirmation from IGDB is a founder action, not a resolved fact
+// (13-handoffs.md §5.2). The seam therefore stays exactly as provider-agnostic
+// as it was designed to be, and removing the hedge because one risk receded
+// would be the wrong lesson — a source that is named today can change its
+// terms tomorrow, which is true of every source and not a fact about IGDB.
+//
+// Nothing in this package names a provider. The word IGDB appears in this
+// comment and nowhere in the API, which is the test of whether a seam is
+// genuinely agnostic: swapping the source must change one implementation and
+// no signature above it.
+//
+// # Having none is a designed state, not an error
+//
+// [Null] is a first-class implementation. When there is no metadata provider,
+// or when the one there is returns nothing, the detail view shows a designed
+// no-metadata composition rather than an error banner. That is the difference
+// between a product that works without a metadata source and a product that is
+// broken without one, and it is why fault.KindNotFound's treatment is
+// TreatmentDesignedEmpty rather than a refusal.
+package metadata
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Provider is a source of enrichment for a game.
+//
+// It is a lookup, not a sync: enrichment is per-game and on demand, because
+// the alternative is fetching 247 records to render twelve rows. The Phase 2
+// enrichment pass that walks the library is a caller of this, and it is the
+// caller that owns the worker count and the rate limiting — not this
+// interface, which stays a single question about a single game.
+type Provider interface {
+	// ID is the source's stable identity, stored on the metadata row so a
+	// library enriched by one source can be re-enriched by another without
+	// guessing which rows came from where.
+	ID() provider.ID
+
+	// Lookup returns what this source knows about one game.
+	//
+	// The result is stamped. There is no way to obtain a Metadata without its
+	// observation time, which is 07 §4's age rule made structural rather than
+	// remembered.
+	//
+	// A game the source has never heard of is fault.KindNotFound, and that is
+	// routine rather than a failure: a hand-added cartridge is the majority
+	// case for a shelf and the designed no-metadata composition is what it
+	// renders. A source that is down is KindUnreachable, which is a different
+	// screen, which is the entire reason the taxonomy exists.
+	//
+	// ctx cancellation must abort in-flight I/O. The Phase 2 enrichment pass
+	// runs many of these concurrently and abandons them when the player
+	// leaves the screen.
+	Lookup(ctx context.Context, r library.Ref) (aged.Value[Metadata], error)
+
+	// Attribution is the credit this source requires, and it is a method
+	// rather than a configuration string.
+	//
+	// The credit a source requires is a property of the source, so swapping
+	// the source swaps the credit automatically and a licence change becomes a
+	// data change instead of a redesign. It is required and it is not optional
+	// to render: the detail view renders whatever this returns.
+	Attribution() Attribution
+}
+
+// Metadata is what a source knows about a game.
+//
+// It carries no age of its own: it is always handed back inside an
+// [aged.Value], which is the mechanism rather than a convention. A FetchedAt
+// field here would be a second, ignorable copy of the same fact.
+type Metadata struct {
+	// Sinopse is the description. The Portuguese word is ratified brand
+	// vocabulary and is carried with a translator note so no future
+	// translation "fixes" it.
+	Sinopse string
+
+	// CoverRef is a local cache path, never a remote URL.
+	//
+	// Nothing renders from the network, so a URL here would be a value no
+	// renderer could legally use — and the one a renderer would eventually
+	// use anyway. The cache lives in the XDG cache directory, outside
+	// library.db, because covers are disposable, refetchable and potentially
+	// large, and the file the player backs up has to stay small enough that
+	// they actually back it up.
+	CoverRef string
+
+	// ReleasedAt is nil when the source did not say.
+	ReleasedAt *time.Time
+
+	// Genres is whatever taxonomy the source uses, unmapped.
+	//
+	// Deliberately not normalised into a Zerado genre enum. A shared
+	// vocabulary across sources is a mapping table that would have to be
+	// maintained against somebody else's taxonomy forever, and Phase 2 renders
+	// these as text.
+	Genres []string
+}
+
+// Empty reports whether this metadata carries nothing worth rendering.
+//
+// A source may legitimately return a record with every field blank. That is
+// the designed no-metadata composition's trigger just as much as a KindNotFound
+// is, and a caller that only checked the error would render an empty pane with
+// three blank labels.
+func (m Metadata) Empty() bool {
+	return m.Sinopse == "" && m.CoverRef == "" && m.ReleasedAt == nil && len(m.Genres) == 0
+}
+
+// Attribution is the credit a source requires.
+type Attribution struct {
+	// TextKey names the catalogue entry that renders the credit line, with
+	// the source's name as an argument.
+	//
+	// A key rather than a sentence, for the same D9 reason as everything else
+	// — and with one deliberate consequence: a source whose licence requires
+	// a specific untranslated wording supplies that wording through
+	// [Attribution.Verbatim] instead, so the catalogue is never asked to
+	// translate a legal obligation.
+	TextKey string
+
+	// Verbatim is a credit line that must appear exactly as given, for a
+	// licence that requires specific wording.
+	//
+	// When it is non-empty it wins over TextKey. This is the one sanctioned
+	// user-facing string in the seams, and it is sanctioned because it is not
+	// language: it is a term of somebody else's licence, and translating it
+	// would breach the thing it exists to satisfy.
+	Verbatim string
+
+	// URL is the source's own link, where its terms require one.
+	URL string
+}
+
+// Null is the metadata provider that knows nothing.
+//
+// It is a designed state and not a fallback, which is why it lives in this
+// package rather than in a test helper: it is the implementation Phase 1 runs
+// with, and it is what the product uses if a source is ever withdrawn. Because
+// it is the default rather than an emergency, the no-metadata composition is
+// the well-exercised path instead of an untested one — the same argument that
+// makes NullAudio the default build.
+type Null struct{}
+
+// ID returns the reserved identity of the no-source source.
+func (Null) ID() provider.ID { return "none" }
+
+// Lookup always reports that nothing is known.
+//
+// It returns KindNotFound rather than an empty success so that a caller
+// distinguishing "nothing is known" from "the record is blank" gets the same
+// answer from Null as it would from a real source that had never heard of the
+// game.
+func (Null) Lookup(context.Context, library.Ref) (aged.Value[Metadata], error) {
+	return aged.Value[Metadata]{}, fault.New(fault.KindNotFound, "metadata.Null.Lookup")
+}
+
+// Attribution returns no credit, because there is no source to credit.
+func (Null) Attribution() Attribution { return Attribution{} }
+
+// Null satisfies Provider — asserted here so the claim is checked by the
+// compiler rather than by a reader.
+var _ Provider = Null{}

--- a/internal/metadata/metadatatest/fake.go
+++ b/internal/metadata/metadatatest/fake.go
@@ -1,0 +1,69 @@
+// Package metadatatest holds a metadata provider backed by a map, so the
+// enrichment path can be exercised with no network and no source.
+package metadatatest
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Fake answers from a map keyed by title and platform.
+//
+// It keys on title and platform rather than on a store identifier, and that is
+// the point rather than a convenience: it is the shape a source that has never
+// heard of Steam would have, which is the shape the seam has to support for a
+// cartridge. A fake keyed on appid would have quietly agreed with a
+// Steam-shaped seam and proved nothing.
+type Fake struct {
+	Ident   provider.ID
+	Records map[string]metadata.Metadata
+	At      time.Time
+	Credit  metadata.Attribution
+
+	// Fail, when set, is returned instead of a lookup — so a test can
+	// exercise the difference between a source that is down (a banner) and a
+	// source that has never heard of a game (a designed empty).
+	Fail error
+}
+
+// New returns a Fake with a fixed observation time.
+func New() *Fake {
+	return &Fake{
+		Ident:   "fake-metadata",
+		Records: map[string]metadata.Metadata{},
+		At:      time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC),
+		Credit:  metadata.Attribution{TextKey: "attribution.fake"},
+	}
+}
+
+// Key builds the map key for a ref.
+func Key(r library.Ref) string { return r.Title + "|" + r.Platform }
+
+// ID returns the fake's identity.
+func (f *Fake) ID() provider.ID { return f.Ident }
+
+// Lookup answers from the map.
+func (f *Fake) Lookup(_ context.Context, r library.Ref) (aged.Value[metadata.Metadata], error) {
+	if f.Fail != nil {
+		return aged.Value[metadata.Metadata]{}, f.Fail
+	}
+	if !r.Identifiable() {
+		return aged.Value[metadata.Metadata]{}, fault.New(fault.KindMalformed, "metadatatest.Lookup")
+	}
+	m, ok := f.Records[Key(r)]
+	if !ok {
+		return aged.Value[metadata.Metadata]{}, fault.New(fault.KindNotFound, "metadatatest.Lookup")
+	}
+	return aged.New(m, f.At), nil
+}
+
+// Attribution returns the fake's credit line.
+func (f *Fake) Attribution() metadata.Attribution { return f.Credit }
+
+var _ metadata.Provider = (*Fake)(nil)

--- a/internal/metadata/null_test.go
+++ b/internal/metadata/null_test.go
@@ -1,0 +1,89 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata/metadatatest"
+)
+
+// TestHavingNoSourceIsADesignedState, not an error. This is the difference
+// between a product that works without a metadata source and a product that is
+// broken without one.
+func TestHavingNoSourceIsADesignedState(t *testing.T) {
+	_, err := metadata.Null{}.Lookup(context.Background(), library.Ref{Title: "Hades", Platform: "PC"})
+	if !fault.Is(err, fault.KindNotFound) {
+		t.Fatalf("got %v, want KindNotFound", fault.KindOf(err))
+	}
+	if got := fault.KindOf(err).Treatment(); got != fault.TreatmentDesignedEmpty {
+		t.Fatalf("no metadata renders as %v; an error banner would make the product broken without a source", got)
+	}
+	if a := (metadata.Null{}).Attribution(); a.TextKey != "" || a.Verbatim != "" {
+		t.Fatal("the null source demands a credit")
+	}
+}
+
+// TestTheSeamNamesNoProvider is the test of whether a seam is genuinely
+// agnostic: swapping the source must change one implementation and no
+// signature above it. A fake keyed on a title and a platform satisfies exactly
+// the same interface a store-aware source would.
+func TestTheSeamNamesNoProvider(t *testing.T) {
+	var sources []metadata.Provider
+
+	null := metadata.Null{}
+	fake := metadatatest.New()
+	r := library.Ref{Title: "Chrono Trigger", Platform: "SNES"}
+	fake.Records[metadatatest.Key(r)] = metadata.Metadata{Sinopse: "A time-travelling RPG."}
+
+	sources = append(sources, null, fake)
+
+	for _, s := range sources {
+		v, err := s.Lookup(context.Background(), r)
+		switch s.(type) {
+		case metadata.Null:
+			if err == nil {
+				t.Fatal("the null source answered")
+			}
+		default:
+			if err != nil {
+				t.Fatalf("%s: %v", s.ID(), err)
+			}
+			if v.V.Empty() {
+				t.Fatalf("%s returned an empty record", s.ID())
+			}
+			if !v.Known() {
+				t.Fatalf("%s returned a record with no observation time", s.ID())
+			}
+		}
+	}
+}
+
+// TestABlankRecordIsAlsoTheDesignedEmpty: a source may legitimately return a
+// record with every field blank, and a caller that only checked the error
+// would render an empty pane with three blank labels.
+func TestABlankRecordIsAlsoTheDesignedEmpty(t *testing.T) {
+	if !(metadata.Metadata{}).Empty() {
+		t.Fatal("a blank record does not report itself empty")
+	}
+	if (metadata.Metadata{Genres: []string{"RPG"}}).Empty() {
+		t.Fatal("a record with a genre reported itself empty")
+	}
+}
+
+// TestASourceThatIsDownIsADifferentScreen from a source that has never heard
+// of a game. That distinction is the entire reason the taxonomy exists.
+func TestASourceThatIsDownIsADifferentScreen(t *testing.T) {
+	fake := metadatatest.New()
+	fake.Fail = fault.New(fault.KindUnreachable, "metadatatest.Lookup")
+
+	_, err := fake.Lookup(context.Background(), library.Ref{Title: "Hades", Platform: "PC"})
+	if fault.KindOf(err).Treatment() == fault.TreatmentDesignedEmpty {
+		t.Fatal("a source being down rendered as a designed empty; the player would never learn there was anything to retry")
+	}
+	if !fault.KindOf(err).Retryable() {
+		t.Fatal("a source being down is not retryable; the banner would offer no way out")
+	}
+}

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,0 +1,194 @@
+// Package pricing is the price seam: what a game costs now, what it has ever
+// cost, and therefore whether to wait.
+//
+// # The disclosure is structural, and there is no affiliate URL
+//
+// Founder direction, 2026-08-25: affiliate links are dropped so that Zerado is
+// cleanly non-commercial — free software, donation-supported, zero revenue.
+// [Quote.URL] is a plain shop link and there is no field that could carry a
+// commission tag. That is a decision rather than an omission, and it is
+// enforced by the absence: a struct with no place to put an affiliate
+// parameter cannot grow one by accident.
+//
+// The price feature survives intact. Current price, the all-time low, when the
+// low was, and the wait-or-buy verdict are all exactly as designed. What went
+// is the tag on the outbound link and the disclosure obligation that used to
+// travel with it.
+//
+// # Every quote carries its age, and the age is not optional
+//
+// A [Quote] is always returned inside an [aged.Value]. 07 §4 is blunt about
+// why: Zerado's value proposition is telling a player *not* to buy something,
+// and a stale price presented as current is not a cosmetic defect but the
+// product giving financial advice from memory. There is no code path that can
+// render the number without the age, because they arrive in the same value.
+//
+// # The verdict is answerable without a second call
+//
+// The ticket requires that "wait or buy?" be answerable from one response, so
+// [Quote] carries the current price, the all-time low and when that low was.
+// [Quote.Verdict] computes the answer locally, offline, from a cached quote —
+// which is what makes the watchlist a DEGRADES feature rather than one that
+// stops.
+package pricing
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Currency is an ISO 4217 code — "BRL", "USD", "EUR".
+//
+// It is a parameter on every lookup rather than a global setting because the
+// budget feature is money in the player's own currency, and a source that can
+// answer in one currency and not another must be able to say so per request.
+type Currency string
+
+// Money is an amount in a currency's minor units.
+//
+// Integer minor units, never a float: a price is not a measurement and 0.1
+// does not exist in binary floating point. The formatting — symbol placement,
+// decimal separator, grouping — is x/text's, at render time, from the player's
+// locale, which is also why this type has no String method that could tempt a
+// screen into formatting money itself.
+type Money struct {
+	// Amount is in minor units: 4999 is BRL 49.99.
+	Amount int64
+
+	// Currency is the code the amount is denominated in. A Money with an
+	// empty Currency is not zero money; it is an unset value, and
+	// [Money.Known] is how a caller tells the difference from a genuine free
+	// game.
+	Currency Currency
+}
+
+// Known reports whether this Money carries a currency and is therefore a real
+// amount.
+func (m Money) Known() bool { return m.Currency != "" }
+
+// Provider is a source of prices.
+type Provider interface {
+	// ID is the source's stable identity.
+	ID() provider.ID
+
+	// Quote returns the current price and the all-time low for one game, in
+	// one currency, stamped with when it was observed.
+	//
+	// A game the source does not sell or does not know is fault.KindNotFound,
+	// which renders as no price rather than as an error: a cartridge has no
+	// shop page and that is not a failure of anything.
+	Quote(ctx context.Context, r library.Ref, cur Currency) (aged.Value[Quote], error)
+
+	// Attribution is the credit this source requires, on the same terms as
+	// the metadata seam's: a property of the source, so swapping the source
+	// swaps the credit.
+	//
+	// The published copy names IsThereAnyDeal as the source of price data, and
+	// it is nevertheless behind this interface for the same reason a metadata
+	// source is: the page's claim is about what the data is, not about who is
+	// guaranteed to supply it forever.
+	Attribution() metadata.Attribution
+}
+
+// Quote is one source's answer about one game's price.
+type Quote struct {
+	// Current is what it costs now.
+	Current Money
+
+	// Low is the all-time low, and LowAt is when it was.
+	//
+	// LowAt is not optional. A low with no date is not information: "it was
+	// R$ 19 once" is a different statement depending on whether once was last
+	// month or in 2019, and only one of those two should make a player wait.
+	Low   Money
+	LowAt time.Time
+
+	// Shop names the retailer, for display.
+	Shop string
+
+	// URL is a plain shop link. No affiliate tag, ever — there is no field
+	// that could carry one and no parameter that may be appended to this.
+	URL string
+}
+
+// DiscountPercent returns how far below the all-time low the current price
+// sits, as a percentage of the low, rounded toward zero.
+//
+// It returns 0 and false when either amount is unknown or the currencies
+// differ, rather than computing across currencies — a percentage derived from
+// two different denominations is a number that looks right and means nothing.
+func (q Quote) DiscountPercent() (int, bool) {
+	if !q.Current.Known() || !q.Low.Known() || q.Current.Currency != q.Low.Currency {
+		return 0, false
+	}
+	if q.Low.Amount <= 0 {
+		return 0, false
+	}
+	diff := q.Current.Amount - q.Low.Amount
+	return int(diff * 100 / q.Low.Amount), true
+}
+
+// Verdict is the wait-or-buy answer.
+type Verdict uint8
+
+const (
+	// VerdictUnknown means there is not enough to say. It renders as no
+	// verdict, never as "wait" — a product that guesses "wait" when it does
+	// not know is a product giving advice it has not earned.
+	VerdictUnknown Verdict = iota
+
+	// VerdictAtLow means the current price is at or below the all-time low.
+	VerdictAtLow
+
+	// VerdictNearLow means the current price is within the tolerance of the
+	// all-time low.
+	VerdictNearLow
+
+	// VerdictWait means the current price is meaningfully above the all-time
+	// low.
+	VerdictWait
+)
+
+// String returns the stable machine name, used by the CLI's JSON output.
+func (v Verdict) String() string {
+	switch v {
+	case VerdictAtLow:
+		return "at_low"
+	case VerdictNearLow:
+		return "near_low"
+	case VerdictWait:
+		return "wait"
+	default:
+		return "unknown"
+	}
+}
+
+// Verdict answers wait-or-buy from this quote alone.
+//
+// tolerancePercent is how far above the all-time low still counts as near it;
+// the caller supplies it because it is a product judgement about what "close
+// enough" means, and Phase 3 will want to tune it without a signature change.
+//
+// It is a method on the quote rather than a provider call because the whole
+// point is that it is answerable offline, from a cached value, with the
+// network down. A verdict computed by the source would be a verdict Zerado
+// could not produce for the watchlist when it matters.
+func (q Quote) Verdict(tolerancePercent int) Verdict {
+	pct, ok := q.DiscountPercent()
+	if !ok {
+		return VerdictUnknown
+	}
+	switch {
+	case pct <= 0:
+		return VerdictAtLow
+	case pct <= tolerancePercent:
+		return VerdictNearLow
+	default:
+		return VerdictWait
+	}
+}

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -116,8 +116,15 @@ type Quote struct {
 	URL string
 }
 
-// DiscountPercent returns how far below the all-time low the current price
+// DiscountPercent returns how far ABOVE the all-time low the current price
 // sits, as a percentage of the low, rounded toward zero.
+//
+// Above, not below: it computes (Current - Low) / Low, so a price at the low
+// returns 0, one below it returns a negative, and a full-price game returns a
+// large positive. That direction is what [Quote.Verdict] reads — pct <= 0 is
+// VerdictAtLow — and the name reads as its opposite, which is why the
+// direction is spelled out here rather than left to be inferred from the
+// arithmetic.
 //
 // It returns 0 and false when either amount is unknown or the currencies
 // differ, rather than computing across currencies — a percentage derived from

--- a/internal/pricing/pricingtest/fake.go
+++ b/internal/pricing/pricingtest/fake.go
@@ -1,0 +1,58 @@
+// Package pricingtest holds a price provider backed by a map.
+package pricingtest
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/pricing"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Fake answers quotes from a map, keyed by title, platform and currency.
+type Fake struct {
+	Ident  provider.ID
+	Quotes map[string]pricing.Quote
+	At     time.Time
+	Credit metadata.Attribution
+	Fail   error
+}
+
+// New returns a Fake with a fixed observation time.
+func New() *Fake {
+	return &Fake{
+		Ident:  "fake-pricing",
+		Quotes: map[string]pricing.Quote{},
+		At:     time.Date(2026, 8, 24, 8, 0, 0, 0, time.UTC),
+		Credit: metadata.Attribution{TextKey: "attribution.fake_prices"},
+	}
+}
+
+// Key builds the map key for a ref and currency.
+func Key(r library.Ref, cur pricing.Currency) string {
+	return r.Title + "|" + r.Platform + "|" + string(cur)
+}
+
+// ID returns the fake's identity.
+func (f *Fake) ID() provider.ID { return f.Ident }
+
+// Quote answers from the map, stamped.
+func (f *Fake) Quote(_ context.Context, r library.Ref, cur pricing.Currency) (aged.Value[pricing.Quote], error) {
+	if f.Fail != nil {
+		return aged.Value[pricing.Quote]{}, f.Fail
+	}
+	q, ok := f.Quotes[Key(r, cur)]
+	if !ok {
+		return aged.Value[pricing.Quote]{}, fault.New(fault.KindNotFound, "pricingtest.Quote")
+	}
+	return aged.New(q, f.At), nil
+}
+
+// Attribution returns the fake's credit line.
+func (f *Fake) Attribution() metadata.Attribution { return f.Credit }
+
+var _ pricing.Provider = (*Fake)(nil)

--- a/internal/pricing/quote_test.go
+++ b/internal/pricing/quote_test.go
@@ -1,0 +1,116 @@
+package pricing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/pricing"
+	"github.com/JustCode-CruzAlex/Zerado/internal/pricing/pricingtest"
+)
+
+// TestAQuoteCannotBeObtainedWithoutItsAge is 07 §4 made structural. There is
+// no code path that renders the number without the age, because they arrive in
+// the same value.
+func TestAQuoteCannotBeObtainedWithoutItsAge(t *testing.T) {
+	f := pricingtest.New()
+	r := library.Ref{Title: "Hades", Platform: "PC"}
+	f.Quotes[pricingtest.Key(r, "BRL")] = pricing.Quote{
+		Current: pricing.Money{Amount: 4999, Currency: "BRL"},
+		Low:     pricing.Money{Amount: 1999, Currency: "BRL"},
+		LowAt:   time.Date(2025, 11, 28, 0, 0, 0, 0, time.UTC),
+		Shop:    "Steam",
+		URL:     "https://store.steampowered.com/app/1145360",
+	}
+
+	v, err := f.Quote(context.Background(), r, "BRL")
+	if err != nil {
+		t.Fatalf("Quote: %v", err)
+	}
+	if !v.Known() {
+		t.Fatal("a quote came back with no observation time")
+	}
+	var _ aged.Value[pricing.Quote] = v // the signature is the guarantee
+}
+
+// TestWaitOrBuyIsAnswerableFromOneResponse, and offline, from a cached value —
+// which is what makes the watchlist a DEGRADES feature rather than one that
+// stops.
+func TestWaitOrBuyIsAnswerableFromOneResponse(t *testing.T) {
+	cases := []struct {
+		name    string
+		current int64
+		low     int64
+		want    pricing.Verdict
+	}{
+		{"at the all-time low", 1999, 1999, pricing.VerdictAtLow},
+		{"below the recorded low", 1799, 1999, pricing.VerdictAtLow},
+		{"a little above it", 2099, 1999, pricing.VerdictNearLow},
+		{"well above it", 4999, 1999, pricing.VerdictWait},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			q := pricing.Quote{
+				Current: pricing.Money{Amount: c.current, Currency: "BRL"},
+				Low:     pricing.Money{Amount: c.low, Currency: "BRL"},
+			}
+			if got := q.Verdict(10); got != c.want {
+				t.Fatalf("Verdict = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestAnUnknowableVerdictIsNeverAdvice: a product that guesses "wait" when it
+// does not know is a product giving advice it has not earned.
+func TestAnUnknowableVerdictIsNeverAdvice(t *testing.T) {
+	for _, q := range []pricing.Quote{
+		{},
+		{Current: pricing.Money{Amount: 4999, Currency: "BRL"}},
+		{Current: pricing.Money{Amount: 4999, Currency: "BRL"}, Low: pricing.Money{Amount: 1999, Currency: "USD"}},
+		{Current: pricing.Money{Amount: 4999, Currency: "BRL"}, Low: pricing.Money{Amount: 0, Currency: "BRL"}},
+	} {
+		if got := q.Verdict(10); got != pricing.VerdictUnknown {
+			t.Fatalf("Verdict(%+v) = %v, want VerdictUnknown", q, got)
+		}
+	}
+}
+
+// TestThereIsNowhereToPutAnAffiliateTag. The decision is enforced by the
+// absence of a field, so it cannot be re-added by accident.
+func TestThereIsNowhereToPutAnAffiliateTag(t *testing.T) {
+	q := pricing.Quote{}
+	// The struct has exactly these fields; a reviewer reading this test sees
+	// the whole surface. Adding an AffiliateURL would not compile here.
+	_ = q.Current
+	_ = q.Low
+	_ = q.LowAt
+	_ = q.Shop
+	_ = q.URL
+}
+
+// TestMoneyDistinguishesUnsetFromFree: an empty currency is an unset value,
+// not a free game.
+func TestMoneyDistinguishesUnsetFromFree(t *testing.T) {
+	if (pricing.Money{}).Known() {
+		t.Fatal("the zero Money claims to be a real amount")
+	}
+	if !(pricing.Money{Amount: 0, Currency: "BRL"}).Known() {
+		t.Fatal("a genuinely free game read as unset")
+	}
+}
+
+// TestNoQuoteIsNotAFailureOfAnything: a cartridge has no shop page.
+func TestNoQuoteIsNotAFailureOfAnything(t *testing.T) {
+	f := pricingtest.New()
+	_, err := f.Quote(context.Background(), library.Ref{Title: "Chrono Trigger", Platform: "SNES"}, "BRL")
+	if !fault.Is(err, fault.KindNotFound) {
+		t.Fatalf("got %v, want KindNotFound", fault.KindOf(err))
+	}
+	if got := fault.KindNotFound.Treatment(); got != fault.TreatmentDesignedEmpty {
+		t.Fatalf("no price renders as %v", got)
+	}
+}

--- a/internal/provider/contract_test.go
+++ b/internal/provider/contract_test.go
@@ -117,6 +117,11 @@ func TestComposeRefusesAnIncompleteForm(t *testing.T) {
 		{"platform": "PS2"},
 		{"title": "Ico"},
 		{"title": "   ", "platform": "PS2"},
+		// Unicode whitespace, for the same reason the credential path checks
+		// it: a title arrives by paste. A NBSP-only title minted into a real
+		// Item is a row whose identity column is invisible.
+		{"title": "\u00a0", "platform": "PS2"},
+		{"title": "Ico", "platform": "\u3000"},
 	} {
 		_, err := m.Compose(e)
 		if err == nil {

--- a/internal/provider/contract_test.go
+++ b/internal/provider/contract_test.go
@@ -1,0 +1,345 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider/providertest"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// TestManualIsNotASyncer is the decision, checked.
+//
+// The compiler can assert that a type implements an interface; it cannot
+// assert that a type deliberately does not. ADR-0001 D1 rejects the
+// alternative — physical implementing Sync and returning ErrManual — because
+// every caller would then have to know which providers lie about their own
+// interface. This test is the only place that rejection is enforceable.
+func TestManualIsNotASyncer(t *testing.T) {
+	m := providertest.NewManual()
+
+	if _, isSyncer := any(m).(provider.Syncer); isSyncer {
+		t.Fatal("the hand-entry provider implements Syncer; it is not a store with a hole where Sync should be")
+	}
+	if _, isProvider := any(m).(provider.Provider); !isProvider {
+		t.Fatal("the hand-entry provider does not implement Provider; a physical copy would be a second-class row")
+	}
+	if _, isEnterer := any(m).(provider.Enterer); !isEnterer {
+		t.Fatal("the hand-entry provider does not implement Enterer")
+	}
+}
+
+// TestCapabilitiesAgreeWithTheInterfaces: Capabilities duplicates two facts
+// the type system already carries, because screens need them before they have
+// a reason to type assert. Duplicated facts drift, so this is the assertion
+// that they have not.
+func TestCapabilitiesAgreeWithTheInterfaces(t *testing.T) {
+	for _, p := range []provider.Provider{providertest.NewManual(), providertest.NewFake()} {
+		if problems := provider.Check(p); len(problems) > 0 {
+			t.Fatalf("%s: %v", p.ID(), problems)
+		}
+	}
+}
+
+// TestACartridgeCannotClaimTelemetry: a hand-entry provider that reported
+// playtime would feed status.Derive a typed number as evidence. Check refuses
+// the declaration rather than leaving it to be noticed on a screen.
+func TestACartridgeCannotClaimTelemetry(t *testing.T) {
+	m := providertest.NewManual()
+	liar := &lyingManual{Manual: m}
+	if problems := provider.Check(liar); len(problems) == 0 {
+		t.Fatal("a hand-entry-only provider claiming Playtime passed Check")
+	}
+}
+
+type lyingManual struct{ *providertest.Manual }
+
+func (l *lyingManual) Capabilities() provider.Capabilities {
+	c := l.Manual.Capabilities()
+	c.Playtime = true
+	return c
+}
+
+// TestHandEntryProducesTheSameValueASyncDoes is the seam's real test. If
+// entering a cartridge needed a different type from a Steam row, the contract
+// would be Steam-shaped and physical would be bolted on.
+func TestHandEntryProducesTheSameValueASyncDoes(t *testing.T) {
+	m := providertest.NewManual()
+	it, err := m.Compose(provider.Entry{
+		"title":       "  Shadow of the Colossus  ",
+		"platform":    "PS2",
+		"owned_since": "2004-11-15",
+	})
+	if err != nil {
+		t.Fatalf("Compose: %v", err)
+	}
+	if it.Title != "Shadow of the Colossus" {
+		t.Fatalf("Title = %q; the form's whitespace reached the library", it.Title)
+	}
+	if it.ProviderRef == "" {
+		t.Fatal("Compose did not mint a provider reference; the player would have to supply an app ID a cartridge does not have")
+	}
+	if it.PlaytimeMinutes != nil {
+		t.Fatal("Compose set a playtime; a cartridge has no telemetry and a zero would be treated as evidence")
+	}
+	if it.OwnedSince == nil {
+		t.Fatal("OwnedSince was dropped; it is the one optional capability physical claims")
+	}
+
+	// The same Item type a sync produces, and the derivation over it agrees
+	// with the provider's capabilities rather than with its identity.
+	if got := status.Derive(0, m.Capabilities().Playtime); got != status.NotStarted {
+		t.Fatalf("a hand-entered game derived to %v", got)
+	}
+}
+
+// TestTwoCartridgesNeverCollide: the ref is minted fresh, so a duplicate is a
+// note rather than a block (Z-08 §8.3).
+func TestTwoCartridgesNeverCollide(t *testing.T) {
+	m := providertest.NewManual()
+	e := provider.Entry{"title": "Shadow of the Colossus", "platform": "PS2"}
+	a, _ := m.Compose(e)
+	b, _ := m.Compose(e)
+	if a.ProviderRef == b.ProviderRef {
+		t.Fatal("two hand entries share a provider reference; the uniqueness constraint would block a legitimate second copy")
+	}
+}
+
+// TestComposeRefusesAnIncompleteForm, with the offending field named so Z-08
+// can put the message under the field it belongs to.
+func TestComposeRefusesAnIncompleteForm(t *testing.T) {
+	m := providertest.NewManual()
+	for _, e := range []provider.Entry{
+		{"platform": "PS2"},
+		{"title": "Ico"},
+		{"title": "   ", "platform": "PS2"},
+	} {
+		_, err := m.Compose(e)
+		if err == nil {
+			t.Fatalf("Compose accepted %v", e)
+		}
+		if !fault.Is(err, fault.KindMalformed) {
+			t.Fatalf("Compose(%v) = %v, want KindMalformed", e, fault.KindOf(err))
+		}
+		if !fault.MessageKeyOf(err).Valid() {
+			t.Fatal("the refusal carries no catalogue key; the field would show a blank error")
+		}
+	}
+}
+
+// TestAStoreNeedsNoScreenChanges: Z-02 renders from the declared credential
+// fields, so adding a provider is implement, declare, register.
+func TestAStoreNeedsNoScreenChanges(t *testing.T) {
+	f := providertest.NewFake()
+	fields := f.Capabilities().Credentials
+	if len(fields) != 2 {
+		t.Fatalf("expected the fake to declare two fields, got %d", len(fields))
+	}
+	if !fields[0].Secret {
+		t.Fatal("the key field is not marked secret; it would be written to library.db")
+	}
+	if fields[1].Secret {
+		t.Fatal("the account field is marked secret; an identifier is not a credential")
+	}
+	if got := provider.Secrets(f.Capabilities()); len(got) != 1 || got[0] != "api_key" {
+		t.Fatalf("Secrets = %v", got)
+	}
+	if got := provider.Missing(f.Capabilities(), provider.Credentials{"api_key": "  "}); len(got) != 2 {
+		t.Fatalf("Missing = %v; whitespace-only must count as absent and the second field is untouched", got)
+	}
+	// A shelf declares none, so Z-02 is never reachable for it.
+	if len(providertest.NewManual().Capabilities().Credentials) != 0 {
+		t.Fatal("the hand-entry provider declares credential fields; Z-02 would open on a screen that can do nothing")
+	}
+}
+
+// TestSyncStreams: a cancel mid-sync leaves a valid partial library, and the
+// stream reports why it stopped after it has closed.
+func TestSyncStreams(t *testing.T) {
+	f := providertest.NewFake(items(5)...)
+	f.Delay = 5 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s, err := f.Sync(ctx, provider.Credentials{"api_key": "k", "account": "a"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	var got int
+	for range s.Items() {
+		got++
+		if got == 2 {
+			cancel()
+		}
+	}
+	if got == 0 {
+		t.Fatal("a cancelled sync delivered nothing; what arrived before the cancel must be kept")
+	}
+	if got == 5 {
+		t.Fatal("the cancel was ignored; the goroutine budget is zero leaks and Esc must abort in-flight I/O")
+	}
+	if !fault.Is(s.Err(), fault.KindCancelled) {
+		t.Fatalf("Err after a cancel = %v, want KindCancelled — Z-03's CANCELLED state is not an error", fault.KindOf(s.Err()))
+	}
+}
+
+// TestPartialIsExpressible is why Stream exists rather than a bare channel:
+// items arrived, then the connection broke, and that is one of Z-03's four
+// terminal states.
+func TestPartialIsExpressible(t *testing.T) {
+	f := providertest.NewFake(items(5)...)
+	f.FailAfterCount = 3
+	f.FailAfter = fault.New(fault.KindUnreachable, "fake.Sync", fault.WithSubject("Fake store"))
+
+	s, err := f.Sync(context.Background(), provider.Credentials{"api_key": "k", "account": "a"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	var got int
+	for range s.Items() {
+		got++
+	}
+	if got != 3 {
+		t.Fatalf("delivered %d items before the break, want 3", got)
+	}
+	if !fault.Is(s.Err(), fault.KindUnreachable) {
+		t.Fatalf("Err = %v; a failure after items have arrived has nowhere to go without Stream.Err", fault.KindOf(s.Err()))
+	}
+}
+
+// TestProgressIsReadableWhileTheSyncRuns is the property Z-03 needs and a bare
+// channel cannot supply: the denominator, so a bar can be drawn instead of an
+// apology, read from the render goroutine while the provider writes.
+//
+// Run with -race, this is also the guard on the contract's "safe to call from
+// another goroutine at any time".
+func TestProgressIsReadableWhileTheSyncRuns(t *testing.T) {
+	f := providertest.NewFake(items(20)...)
+	f.Delay = time.Millisecond
+
+	s, err := f.Sync(context.Background(), provider.Credentials{"api_key": "k", "account": "a"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if p := s.Progress(); !p.Determinate() {
+		t.Fatal("the denominator is unknown before the first item; Z-03 could not draw a determinate bar")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range s.Items() {
+		}
+	}()
+	for {
+		p := s.Progress() // concurrent with the producer, on purpose
+		if p.Seen == 20 {
+			break
+		}
+		select {
+		case <-done:
+			if s.Progress().Seen != 20 {
+				t.Errorf("Seen = %d after the stream closed, want 20", s.Progress().Seen)
+			}
+			return
+		default:
+		}
+	}
+	<-done
+}
+
+// TestAnUnknownDenominatorDrawsTheScanner: a provider that cannot say how many
+// are coming must not be forced to invent a total.
+func TestAnUnknownDenominatorDrawsTheScanner(t *testing.T) {
+	f := providertest.NewFake(items(3)...)
+	f.AnnounceTotal = false
+	s, _ := f.Sync(context.Background(), provider.Credentials{"api_key": "k", "account": "a"})
+	if s.Progress().Determinate() {
+		t.Fatal("Determinate is true with no announced total")
+	}
+	for range s.Items() {
+	}
+}
+
+// TestAZeroTotalIsNotUnknown: zero is a real total — it is the private-profile
+// case — and a screen reading it as "unknown" would scan forever for a sync
+// that has truthfully finished.
+func TestAZeroTotalIsNotUnknown(t *testing.T) {
+	f := providertest.NewFake()
+	s, _ := f.Sync(context.Background(), provider.Credentials{"api_key": "k", "account": "a"})
+	for range s.Items() {
+	}
+	p := s.Progress()
+	if !p.TotalKnown {
+		t.Fatal("an announced total of zero reported itself unknown")
+	}
+	if p.Determinate() {
+		t.Fatal("a total of zero drew a determinate bar; there is nothing to fill")
+	}
+}
+
+// TestStalledIsNotWaiting: a sync that has delivered nothing yet is waiting,
+// which already has its own component, and calling it stalled would flip the
+// screen for no reason the player could see.
+func TestStalledIsNotWaiting(t *testing.T) {
+	base := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	waiting := provider.Progress{Seen: 0}
+	if waiting.Stalled(base.Add(time.Minute), 10*time.Second) {
+		t.Fatal("a sync that has not yet delivered anything reported itself stalled")
+	}
+	moving := provider.Progress{Seen: 5, LastAt: base}
+	if !moving.Stalled(base.Add(11*time.Second), 10*time.Second) {
+		t.Fatal("eleven seconds without an item was not reported as stalled")
+	}
+	if moving.Stalled(base.Add(3*time.Second), 10*time.Second) {
+		t.Fatal("three seconds without an item was reported as stalled")
+	}
+}
+
+// TestARejectedKeyFailsBeforeAnythingStreams.
+func TestARejectedKeyFailsBeforeAnythingStreams(t *testing.T) {
+	f := providertest.NewFake(items(3)...)
+	_, err := f.Sync(context.Background(), provider.Credentials{})
+	if err == nil {
+		t.Fatal("Sync accepted empty credentials")
+	}
+	if !fault.Is(err, fault.KindUnauthorized) {
+		t.Fatalf("got %v, want KindUnauthorized", fault.KindOf(err))
+	}
+}
+
+// TestRegistryRoutesWithoutSwitchingOnIdentity: nothing has to know that
+// physical exists in order to skip it.
+func TestRegistryRoutesWithoutSwitchingOnIdentity(t *testing.T) {
+	r := provider.NewRegistry(providertest.NewFake(), providertest.NewManual())
+	if got := len(r.Syncers()); got != 1 {
+		t.Fatalf("Syncers = %d, want 1", got)
+	}
+	if got := len(r.Enterers()); got != 1 {
+		t.Fatalf("Enterers = %d, want 1", got)
+	}
+	if _, ok := r.Get("physical"); !ok {
+		t.Fatal("the registry cannot resolve a stored provider id back to a provider")
+	}
+	if dup := r.Duplicates(providertest.NewFake(), providertest.NewFake()); len(dup) != 1 {
+		t.Fatalf("Duplicates = %v, want one entry", dup)
+	}
+}
+
+func items(n int) []provider.Item {
+	out := make([]provider.Item, n)
+	for i := range out {
+		m := i * 10
+		out[i] = provider.Item{
+			ProviderRef:     string(rune('a' + i)),
+			Title:           "Game " + string(rune('A'+i)),
+			Platform:        "PC",
+			PlaytimeMinutes: &m,
+		}
+	}
+	return out
+}

--- a/internal/provider/contract_test.go
+++ b/internal/provider/contract_test.go
@@ -2,6 +2,7 @@ package provider_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -149,6 +150,15 @@ func TestAStoreNeedsNoScreenChanges(t *testing.T) {
 	}
 	if got := provider.Missing(f.Capabilities(), provider.Credentials{"api_key": "  "}); len(got) != 2 {
 		t.Fatalf("Missing = %v; whitespace-only must count as absent and the second field is untouched", got)
+	}
+	// A pasted credential is a plausible source of non-ASCII whitespace, in a
+	// product that is internationalised from the first line. A key that is
+	// only a NO-BREAK SPACE must be caught here, inline under the field, and
+	// not by a network round trip that comes back as a rejected key.
+	for _, blank := range []string{"\u00a0", "\u3000", "\u2003\u00a0"} {
+		if got := provider.Missing(f.Capabilities(), provider.Credentials{"api_key": blank, "account": "a"}); len(got) != 1 {
+			t.Fatalf("Missing with %q = %v; Unicode whitespace read as a real value", blank, got)
+		}
 	}
 	// A shelf declares none, so Z-02 is never reachable for it.
 	if len(providertest.NewManual().Capabilities().Credentials) != 0 {
@@ -325,8 +335,38 @@ func TestRegistryRoutesWithoutSwitchingOnIdentity(t *testing.T) {
 	if _, ok := r.Get("physical"); !ok {
 		t.Fatal("the registry cannot resolve a stored provider id back to a provider")
 	}
-	if dup := r.Duplicates(providertest.NewFake(), providertest.NewFake()); len(dup) != 1 {
-		t.Fatalf("Duplicates = %v, want one entry", dup)
+}
+
+// TestDuplicateRegistrationIsVisible is the MINOR-2 repair from the review at
+// c4c8d95.
+//
+// Duplicates used to be a method that ignored its receiver, so the natural
+// call returned nil whatever the registry held, and the only call that did
+// anything re-passed the slice it had already handed NewRegistry. Both halves
+// are now asserted: the package-level check before construction, and what a
+// built registry actually swallowed.
+func TestDuplicateRegistrationIsVisible(t *testing.T) {
+	a, b := providertest.NewFake(), providertest.NewFake()
+
+	if dup := provider.Duplicates(a, b); len(dup) != 1 || dup[0] != a.ID() {
+		t.Fatalf("Duplicates = %v, want [%s]", dup, a.ID())
+	}
+	if dup := provider.Duplicates(a, providertest.NewManual()); len(dup) != 0 {
+		t.Fatalf("Duplicates reported %v for two distinct providers", dup)
+	}
+
+	// The question a method on Registry has to be able to answer, and could
+	// not: what did THIS registry swallow?
+	r := provider.NewRegistry(a, b, providertest.NewManual())
+	got := r.Collisions()
+	if len(got) != 1 || got[0] != a.ID() {
+		t.Fatalf("Collisions = %v, want [%s]", got, a.ID())
+	}
+	if len(r.All()) != 2 {
+		t.Fatalf("the registry holds %d providers, want 2 — the duplicate replaced rather than added", len(r.All()))
+	}
+	if len(provider.NewRegistry(a, providertest.NewManual()).Collisions()) != 0 {
+		t.Fatal("a clean registry reported a collision")
 	}
 }
 
@@ -342,4 +382,38 @@ func items(n int) []provider.Item {
 		}
 	}
 	return out
+}
+
+// TestEveryProgressFieldIsActuallyWritten is the MINOR-1 repair from the
+// review at c4c8d95, generalised.
+//
+// Progress carried a Batches field that no interface method allowed anyone to
+// write, so it could only ever read zero — and the screen it existed for would
+// have rendered "The 0 that arrived are in your library", which is the exact
+// sentence PARTIAL exists to make true.
+//
+// A field on a snapshot that nothing can write is not a contract, it is a
+// promise the type cannot keep. This walks Progress by reflection after a real
+// stream has run and fails on any field still at its zero value, so the next
+// unwritable field is caught at the moment it is added rather than by the
+// screen that trusted it.
+func TestEveryProgressFieldIsActuallyWritten(t *testing.T) {
+	f := providertest.NewFake(items(3)...)
+	s, err := f.Sync(context.Background(), provider.Credentials{"api_key": "k", "account": "a"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	for range s.Items() {
+	}
+
+	v := reflect.ValueOf(s.Progress())
+	for i := 0; i < v.NumField(); i++ {
+		name := v.Type().Field(i).Name
+		if v.Field(i).IsZero() {
+			t.Errorf("Progress.%s is still its zero value after a complete sync.\n"+
+				"Either a conforming implementation cannot write it — in which case it is a\n"+
+				"promise the type cannot keep and belongs somewhere a writer exists — or the\n"+
+				"fake is not exercising it, which makes every screen that reads it untested.", name)
+		}
+	}
 }

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -1,0 +1,119 @@
+package provider
+
+// CredentialField is one field on Z-02, declared by the provider that needs
+// it.
+//
+// The screen renders from this slice and knows nothing else. Adding GOG is:
+// implement the interfaces, declare the fields, register — zero screens, zero
+// routes, zero schema changes. That is the test of whether this seam is right,
+// and it is why Z-02 is named "connect a store" rather than "connect Steam".
+type CredentialField struct {
+	// Key names the field to the provider and to the Vault — "api_key",
+	// "steam_id". It is never rendered.
+	Key string
+
+	// LabelKey, HelpKey name catalogue entries.
+	LabelKey string
+	HelpKey  string
+
+	// HelpURL is where the player goes to get this value.
+	//
+	// A URL rather than a key, because it is not language: it is an address,
+	// and a translated address would be a broken one.
+	HelpURL string
+
+	// Secret decides the field's destination, not merely its masking.
+	//
+	// True means the value is masked on screen AND written to the Vault,
+	// never to library.db. False means it is an identifier — the Steam ID, a
+	// GOG username — and it lives in provider_connection.account_ref.
+	//
+	// One boolean carrying both facts is deliberate: a masked field that was
+	// nonetheless stored in the library file would be the exact failure
+	// 06 §5.4 is written to prevent, and the only way to have that failure
+	// here is to type two booleans and disagree with yourself.
+	Secret bool
+
+	// Validate is the provider's own local check, run before the network is
+	// touched at all.
+	//
+	// It returns a catalogue key naming what is wrong, or "" when the value is
+	// acceptable. A key rather than an error because the result is rendered
+	// under the field, in the player's language.
+	//
+	// Z-02 §8.2 constrains what it may reject, and the constraint is
+	// deliberately severe: Steam's Validate rejects empty and whitespace-only
+	// and nothing else — no length, no character class, no format. A format
+	// assertion is a claim about somebody else's API, and if it is wrong, or
+	// right today and wrong next year, the product refuses a valid credential
+	// on its own authority. The provider's verdict is the only one that
+	// matters, and Z-02 §8.1 goes and gets it.
+	//
+	// nil means nothing is checked locally, which is a legitimate choice and
+	// not an omission.
+	Validate func(string) string
+}
+
+// Credentials is a provider's own key set, keyed by [CredentialField.Key].
+//
+// It never leaves the machine except to the service it belongs to. Three rules
+// hold it to that, and each is a property of this type rather than a habit:
+//
+//   - it is passed only to the provider that declared the fields;
+//   - it is never placed in a [fault], a log line or an [Item];
+//   - it never crosses the Phase 4 sync boundary, which is why
+//     internal/devicesync has no field that could carry one.
+//
+// A map rather than a struct, for the same reason [Entry] is: the field set is
+// the provider's to declare.
+type Credentials map[string]string
+
+// Secrets returns the keys of fields the provider declared as secret.
+//
+// It exists so that a caller assembling Credentials from the Vault, or a log
+// sink redacting them, can do so from the provider's own declaration rather
+// than from a list of names it maintains separately — the second list being
+// the one that goes stale the day a provider adds a field.
+func Secrets(c Capabilities) []string {
+	var out []string
+	for _, f := range c.Credentials {
+		if f.Secret {
+			out = append(out, f.Key)
+		}
+	}
+	return out
+}
+
+// Missing returns the keys of required credential fields that are absent or
+// blank in creds.
+//
+// Every declared field is required; a provider that wants an optional one
+// declares it as an entry field on a form instead. Returned in declaration
+// order so Z-02 can focus the first offender, which is what its empty-submit
+// state does.
+func Missing(c Capabilities, creds Credentials) []string {
+	var out []string
+	for _, f := range c.Credentials {
+		if isBlank(creds[f.Key]) {
+			out = append(out, f.Key)
+		}
+	}
+	return out
+}
+
+// isBlank reports whether s is empty or only whitespace.
+//
+// Spelled out rather than deferring to strings.TrimSpace so that the rule is
+// visible at the one place the contract states it: empty and whitespace-only
+// are the two things every provider's Validate may reject.
+func isBlank(s string) bool {
+	for _, r := range s {
+		switch r {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -1,5 +1,7 @@
 package provider
 
+import "unicode"
+
 // CredentialField is one field on Z-02, declared by the provider that needs
 // it.
 //
@@ -103,15 +105,20 @@ func Missing(c Capabilities, creds Credentials) []string {
 
 // isBlank reports whether s is empty or only whitespace.
 //
-// Spelled out rather than deferring to strings.TrimSpace so that the rule is
-// visible at the one place the contract states it: empty and whitespace-only
-// are the two things every provider's Validate may reject.
+// Whitespace means unicode.IsSpace, not the four ASCII characters an earlier
+// version of this function checked. A credential arrives by paste, from a web
+// page, in a product that is internationalised from the first line — so
+// U+00A0 NO-BREAK SPACE and U+3000 IDEOGRAPHIC SPACE are entirely plausible
+// and would otherwise read as a non-blank value, sending a whitespace-only key
+// to the provider and turning an inline field message into a network round
+// trip and a rejected-key refusal.
+//
+// This is the only thing every provider's Validate may reject (Z-02 §8.2), so
+// getting its definition of "blank" wrong is the one local check the product
+// performs being wrong.
 func isBlank(s string) bool {
 	for _, r := range s {
-		switch r {
-		case ' ', '\t', '\n', '\r':
-			continue
-		default:
+		if !unicode.IsSpace(r) {
 			return false
 		}
 	}

--- a/internal/provider/item.go
+++ b/internal/provider/item.go
@@ -1,0 +1,149 @@
+package provider
+
+import "time"
+
+// Item is a provider's view of one owned title.
+//
+// It is what crosses the seam, in both directions of origin: a Steam response
+// row becomes an Item, and so does a completed Z-08 form. That symmetry is the
+// test the ticket asks for — if hand entry needed a different type, the seam
+// would be Steam-shaped.
+//
+// # Every optional field is a pointer, and that is load-bearing
+//
+// Z-05 distinguishes three facts that a nullable column and a zero value
+// cannot tell apart on their own:
+//
+//	"not tracked"   — the provider cannot ever know (Capabilities.Playtime false)
+//	"—"             — not fetched yet (the field is nil)
+//	"0h" / "never"  — the provider answered, and the answer was nothing
+//
+// The capability answers the first. The pointer answers the second and third.
+// Collapsing either distinction produces a screen that tells a player their
+// cartridge has been played for zero hours, which is a claim nothing could
+// have made.
+type Item struct {
+	// ProviderRef is the provider's own identifier for this title — a Steam
+	// appid, or a UUID Zerado minted for a hand-entered cartridge.
+	//
+	// Together with the provider ID it is the uniqueness constraint, which is
+	// why a hand-entered duplicate is a note and never a block: the ref is
+	// fresh every time, so two copies of the same cartridge are two rows and
+	// nothing collides (Z-08 §8.3).
+	ProviderRef string
+
+	// Title is what the player calls it. Required.
+	Title string
+
+	// Platform is required, and it is half of the Phase 4 merge identity.
+	//
+	// Required even for Steam, where it is unglamorous, because a UID derived
+	// from title alone would merge a PS2 disc with its PC remaster on two
+	// devices that had every reason to keep them apart.
+	Platform string
+
+	// PlaytimeMinutes is provider-reported. nil means not reported.
+	//
+	// Zero is a real value and is distinct from nil. A provider whose
+	// Capabilities.Playtime is false must always send nil here: sending a
+	// zero would feed status.Derive a number it would treat as evidence.
+	PlaytimeMinutes *int
+
+	// LastPlayed is provider-reported. nil means not reported, which is not
+	// the same as never played — Z-05 renders those as "—" and "never
+	// played" respectively.
+	LastPlayed *time.Time
+
+	// OwnedSince is when the player acquired it, where that is knowable.
+	OwnedSince *time.Time
+
+	// Extra carries provider-specific identifiers a later phase will want,
+	// keyed by a name the provider owns — "steam_appid", "gog_id".
+	//
+	// It is a deliberately narrow escape hatch and it has one rule: nothing
+	// above this seam may read a key by name. The store persists what it
+	// recognises and drops what it does not, so a provider can start emitting
+	// a new key without a schema change and without a screen learning about
+	// it. A screen reading Extra["steam_appid"] has reintroduced the switch on
+	// provider identity that this whole seam exists to remove.
+	Extra map[string]string
+}
+
+// Playtime returns the reported playtime and whether it was reported.
+//
+// Callers use this rather than dereferencing, because the two-value form makes
+// the "not reported" branch impossible to forget at a call site — which is
+// exactly the branch Z-05 renders differently.
+func (i Item) Playtime() (int, bool) {
+	if i.PlaytimeMinutes == nil {
+		return 0, false
+	}
+	return *i.PlaytimeMinutes, true
+}
+
+// EntryField is one field on the hand-entry form, declared by the provider
+// that will receive it.
+//
+// It is the Z-08 twin of [CredentialField], and the two are separate types on
+// purpose: a credential is a secret with a destination (the Vault) and a
+// help URL, and an entry field is a data field with a default and a
+// requirement. Merging them would give each half the other's irrelevant
+// fields, and would put Secret on a form where it can only ever be false.
+type EntryField struct {
+	// Key names the field to the provider — "title", "platform", "state",
+	// "owned_since". It is never rendered.
+	Key string
+
+	// LabelKey and HelpKey name catalogue entries. They are keys rather than
+	// strings because these are user-facing text and ADR-0001 D9 admits no
+	// literal.
+	LabelKey string
+	HelpKey  string
+
+	// Kind tells the screen which editor to render.
+	Kind FieldKind
+
+	// Required drives the empty-submit refusal. Z-08 asks for four fields and
+	// requires two, because a cartridge has a title and a platform and may
+	// have nothing else.
+	Required bool
+
+	// Options is the choice set for FieldChoice, in display order. Each entry
+	// is a stored value plus a catalogue key for its label.
+	Options []FieldOption
+}
+
+// FieldKind is the editor a form field needs.
+//
+// The set is closed and small: it is the set Z-02 and Z-08 between them
+// render, and a provider that needs a sixth kind is a provider asking for a
+// screen change, which is exactly the event this seam is supposed to make
+// visible rather than easy.
+type FieldKind uint8
+
+const (
+	// FieldText is a single-line text editor.
+	FieldText FieldKind = iota
+
+	// FieldChoice is a fixed list rendered as chips, one selected.
+	FieldChoice
+
+	// FieldDate is a date, entered as text and parsed by the provider.
+	FieldDate
+)
+
+// FieldOption is one entry in a [FieldChoice] field.
+type FieldOption struct {
+	// Value is the stored form — "not_started".
+	Value string
+
+	// LabelKey names the catalogue entry that renders it.
+	LabelKey string
+}
+
+// Entry is a completed hand-entry form, keyed by [EntryField.Key].
+//
+// A map rather than a struct because the field set is the provider's to
+// declare: a struct here would mean the screen and the seam agreeing on a
+// shape in advance, which is the coupling Z-08 exists without.
+type Entry map[string]string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,206 @@
+// Package provider is the seam every source of owned games satisfies —
+// including the ones that are a person with a keyboard.
+//
+// # Designed against the cartridge, not against Steam
+//
+// The likeliest way to get this seam wrong is to design it around Steam,
+// because Steam is the only provider Phase 1 builds. So the shape below was
+// written against manual physical entry first and checked against Steam
+// second, which is the reverse of the tempting order and the reason the
+// contract has two capability interfaces rather than one.
+//
+// A physical cartridge is not a store. It has no API, no credentials, no
+// pagination, no rate limit, no playtime and no last-played date. Its "sync"
+// is a person typing into Z-08. Every one of those absences is a place where a
+// Steam-shaped interface would have forced physical to lie — by implementing
+// Sync and returning an error, by declaring credential fields it does not
+// want, or by reporting a playtime of zero that the derivation would then
+// treat as a fact.
+//
+// # Interface segregation is the whole design
+//
+//	Provider   — every source implements it. Identity, display name, capabilities.
+//	Syncer     — a source that can fetch a library over a network.
+//	Enterer    — a source whose items arrive because a person entered them.
+//
+// steam implements Provider + Syncer. physical implements Provider + Enterer.
+// A future GOG that both syncs and lets a player add a game the API missed
+// implements all three, and nothing above it changes.
+//
+// ADR-0001 D1 rejects the one-interface alternative for a stated reason: if
+// physical implemented Syncer and returned ErrManual, every caller would have
+// to know which providers lie about their own interface, and the error would
+// be a runtime rediscovery of a fact the type system could have carried.
+//
+// # Everything downstream reads Capabilities, never the ID
+//
+// The row renderer, the state derivation, the filter, the summary counts and
+// the detail view all read [Capabilities]. A switch on [ID] anywhere above this
+// package is the defect this seam exists to prevent, and it is the defect that
+// makes adding GOG a six-file change instead of a one-package change.
+//
+// # No provider constructs its own HTTP client
+//
+// 06-data-seams.md §7 makes this explicit and 07-offline-contract.md §7.3
+// makes it a review rule: a shared *http.Client with a timeout is injected.
+// That is what keeps "works offline" from quietly stopping being true, and it
+// is why this package exposes no client, no transport and no URL.
+package provider
+
+import "context"
+
+// ID is a provider's stable machine identity: "steam", "physical",
+// "playstation", "gog", "ea".
+//
+// It is a database value and a CLI argument, so it is API. It is *not* a
+// dispatch key: code above this package that switches on an ID has bypassed
+// [Capabilities] and will be wrong about the next provider. The one legitimate
+// use above the seam is looking a provider up in a [Registry].
+type ID string
+
+// Provider is what every source of games implements, including the ones that
+// are a human with a keyboard.
+//
+// It is deliberately tiny. Everything a screen needs to decide what to render
+// is here, and nothing here does I/O — which is what lets Z-02 build its form,
+// Z-04 render a row and Z-05 decide which fields exist, all with the network
+// off and with no provider having been contacted.
+type Provider interface {
+	// ID returns the stable machine identity.
+	ID() ID
+
+	// Display returns the player-facing name — "Steam", "Physical shelf".
+	//
+	// It is a plain string rather than an i18n key, and that is a considered
+	// exception to ADR-0001 D9 rather than a hole in it. A provider's name is
+	// a proper noun: "Steam" is "Steam" in every language, and routing it
+	// through a catalogue would invite a translator to translate a brand.
+	// Where a provider's name is genuinely a phrase rather than a brand —
+	// "Physical shelf" — the provider returns a catalogue-rendered string,
+	// because it holds a printer and a screen does not.
+	Display() string
+
+	// Capabilities reports what this provider can actually do.
+	//
+	// It must be a pure function of the provider's own nature — never of its
+	// current connection state, never of whether the network is up, and never
+	// of the player's settings. A capability that changes when a request fails
+	// would make the *shape* of a screen flicker with the weather, and 07 §1
+	// is explicit that a feature is never in two offline classes.
+	Capabilities() Capabilities
+}
+
+// Capabilities is what a provider can do, in the terms screens actually ask
+// about.
+//
+// Every field answers a question some screen has. Nothing here is
+// informational: a capability nobody reads is a capability that will drift out
+// of truth unnoticed.
+type Capabilities struct {
+	// Sync reports whether this provider can fetch a library over a network.
+	//
+	// True exactly when the provider also implements [Syncer]. The redundancy
+	// is deliberate: a screen needs to decide whether to offer "sync" before
+	// it has a reason to type-assert anything, and 07's offline classification
+	// is a property of the provider rather than of a Go type assertion.
+	// [Check] asserts the two agree.
+	Sync bool
+
+	// Manual reports whether items may be entered by hand for this provider.
+	//
+	// True exactly when the provider also implements [Enterer]. This is the
+	// field Z-01's "Add a game by hand" door and Z-08 read, and it is the
+	// field that makes physical a first-class source rather than a flag.
+	Manual bool
+
+	// Playtime reports whether this provider can ever know how long a game
+	// has been played.
+	//
+	// It drives status.Derive, and it is the difference between "0h" and "not
+	// tracked" on Z-05 — two facts that look identical in a database and are
+	// completely different on a screen. A cartridge has no telemetry, so
+	// physical reports false and all four of its states are the player's.
+	Playtime bool
+
+	// LastPlayed reports whether this provider can supply a last-played
+	// timestamp. When false, Z-03's DONE line omits the third fact entirely
+	// rather than rendering it empty.
+	LastPlayed bool
+
+	// OwnedSince reports whether an acquisition date is available. It is the
+	// one optional capability physical claims, because a player entering a
+	// cartridge genuinely knows when they got it.
+	OwnedSince bool
+
+	// Credentials lists the fields Z-02 renders, in the order it renders
+	// them. Empty means the provider needs none — which is the physical case,
+	// and the reason Z-02 is reachable only for providers that have some.
+	Credentials []CredentialField
+}
+
+// Syncer is implemented only by providers that can fetch a library.
+//
+// physical does not implement it, and that is the point: it is not a
+// Steam-shaped provider with a hole where Sync should be.
+type Syncer interface {
+	Provider
+
+	// Sync streams this provider's current view of the library.
+	//
+	// It returns as soon as the request is under way — before any item has
+	// arrived — so that Z-03 can paint its indeterminate state immediately
+	// rather than after a round trip. A failure that is known at that moment
+	// (no route, a rejected key) is returned as the error; a failure that
+	// happens later, after items have already been delivered, arrives through
+	// [Stream.Err] and is the PARTIAL case.
+	//
+	// Cancelling ctx MUST abort in-flight I/O and close the stream promptly.
+	// Z-03 lets the player press Esc mid-sync and the goroutine budget for the
+	// whole product is zero leaks, so a provider that ignores cancellation is
+	// not merely impolite — it holds the process open at quit.
+	//
+	// What arrives before a cancel stays: 06 §2.5 requires that a cancel
+	// mid-sync leaves a valid partial library, which is why this streams at
+	// all rather than returning a slice.
+	Sync(ctx context.Context, c Credentials) (Stream, error)
+}
+
+// Enterer is implemented only by providers whose items arrive because a person
+// entered them.
+//
+// This is the interface that keeps physical honest. Without it, hand entry
+// would be a screen writing directly into the store, and the two rules that
+// make a hand-entered row a real row — that its provider_ref is a UUID Zerado
+// mints rather than something the player has to find, and that its optional
+// fields respect the provider's own capabilities — would live in the screen
+// instead of in the provider.
+//
+// It is a capability, not a provider kind. A future GOG that syncs *and* lets
+// a player add a game its API missed implements both this and [Syncer], and
+// Z-08 gains a source picker rather than a special case.
+type Enterer interface {
+	Provider
+
+	// Form returns the fields Z-08 renders, in order.
+	//
+	// It is the hand-entry twin of Capabilities().Credentials, and it exists
+	// for the same reason: the screen renders what the provider declares, so
+	// a new hand-enterable source adds zero screens.
+	Form() []EntryField
+
+	// Compose turns a completed form into an [Item].
+	//
+	// The provider mints the ProviderRef — for physical, a fresh UUID, so a
+	// duplicate can never collide and 06 §2.2's uniqueness constraint holds
+	// without the player being asked for an app ID a cartridge does not have.
+	//
+	// It validates and it does not write. The store is the only writer, and
+	// Compose returning an Item rather than performing an insert is what keeps
+	// hand entry on exactly the same path as a sync: both produce Items, and
+	// both go through the same upsert.
+	//
+	// A validation failure is a fault.KindMalformed carrying the offending
+	// field's key, so Z-08 can put the message under the field it belongs to
+	// rather than in a banner.
+	Compose(e Entry) (Item, error)
+}

--- a/internal/provider/providertest/fake.go
+++ b/internal/provider/providertest/fake.go
@@ -1,0 +1,194 @@
+package providertest
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Fake is a scriptable Syncer that reaches no network.
+//
+// It exists to prove the property the ticket makes a requirement: every seam
+// is fakeable with no network, and if it cannot be tested offline the shape is
+// wrong. Everything Z-03 has to render is scriptable here — a slow first
+// round trip, a known or unknown denominator, a stream that breaks halfway, a
+// rejected key, and a successful call that returns nothing at all.
+//
+// It is a test double and not a reference implementation: a real Syncer's
+// interesting parts are HTTP, pagination and rate limits, none of which this
+// has. What it does share with a real one is the contract — items on a
+// channel, cancellation honoured, terminal error after close, progress readable
+// concurrently — which is the part a test needs to exercise.
+type Fake struct {
+	// Ident and Name are what the provider reports about itself.
+	Ident provider.ID
+	Name  string
+
+	// Caps is what it claims it can do. Defaults to a Steam-shaped set.
+	Caps provider.Capabilities
+
+	// Items is the library it will stream.
+	Items []provider.Item
+
+	// FailBefore, when set, makes Sync return this error immediately, before
+	// any item — the case that becomes Z-03's FAILED.
+	FailBefore error
+
+	// FailAfter, when set, ends the stream with this error after
+	// FailAfterCount items — the case that becomes PARTIAL, and the reason
+	// Stream carries a terminal error at all.
+	FailAfter      error
+	FailAfterCount int
+
+	// AnnounceTotal makes the stream publish its denominator, which is what
+	// lets Z-03 draw a determinate bar instead of an indeterminate scanner.
+	// False models a provider that cannot say how many are coming.
+	AnnounceTotal bool
+
+	// Delay is slept between items, so a test can exercise cancellation
+	// mid-stream. Zero streams as fast as the consumer reads.
+	Delay time.Duration
+}
+
+// NewFake returns a Fake with a Steam-shaped capability set.
+func NewFake(items ...provider.Item) *Fake {
+	return &Fake{
+		Ident: "fake",
+		Name:  "Fake store",
+		Caps: provider.Capabilities{
+			Sync: true, Playtime: true, LastPlayed: true, OwnedSince: true,
+			Credentials: []provider.CredentialField{
+				{Key: "api_key", LabelKey: "cred.api_key.label", Secret: true},
+				{Key: "account", LabelKey: "cred.account.label"},
+			},
+		},
+		Items:         items,
+		AnnounceTotal: true,
+	}
+}
+
+// ID returns the fake's identity.
+func (f *Fake) ID() provider.ID { return f.Ident }
+
+// Display returns the fake's player-facing name.
+func (f *Fake) Display() string { return f.Name }
+
+// Capabilities returns the declared capability set.
+func (f *Fake) Capabilities() provider.Capabilities { return f.Caps }
+
+// Sync streams the scripted items.
+//
+// It honours cancellation at every step, including while sleeping, because a
+// provider that only checks ctx between items would pass a fast test and hang
+// the product on a slow network — and Z-03 lets the player press Esc at
+// exactly that moment.
+//
+// Missing credentials are rejected before anything is streamed, using the
+// provider's own declared field set rather than a hard-coded list, which is
+// the same check Z-02's empty-submit state performs.
+func (f *Fake) Sync(ctx context.Context, c provider.Credentials) (provider.Stream, error) {
+	if f.FailBefore != nil {
+		return nil, f.FailBefore
+	}
+	if missing := provider.Missing(f.Caps, c); len(missing) > 0 {
+		return nil, fault.New(fault.KindUnauthorized, "fake.Sync",
+			fault.WithSubject(f.Name), fault.WithMessage("fault.unauthorized"))
+	}
+
+	s := &stream{ch: make(chan provider.Item)}
+	if f.AnnounceTotal {
+		s.setTotal(len(f.Items))
+	}
+
+	go func() {
+		defer close(s.ch)
+		for i, it := range f.Items {
+			if f.FailAfter != nil && i >= f.FailAfterCount {
+				s.setErr(f.FailAfter)
+				return
+			}
+			if f.Delay > 0 {
+				select {
+				case <-ctx.Done():
+					s.setErr(cancelled(ctx))
+					return
+				case <-time.After(f.Delay):
+				}
+			}
+			select {
+			case <-ctx.Done():
+				s.setErr(cancelled(ctx))
+				return
+			case s.ch <- it:
+				s.advance()
+			}
+		}
+		if f.FailAfter != nil && len(f.Items) >= f.FailAfterCount {
+			s.setErr(f.FailAfter)
+		}
+	}()
+	return s, nil
+}
+
+// cancelled turns a context's own error into a classified fault, so that a
+// caller switching on fault.Kind sees KindCancelled rather than an
+// unclassified error that would render as the fatal screen.
+func cancelled(ctx context.Context) error {
+	return fault.New(fault.KindCancelled, "fake.Sync", fault.WithCause(ctx.Err()))
+}
+
+// stream is the Fake's Stream implementation.
+//
+// Its progress snapshot is mutex-guarded rather than raced, because the
+// contract on provider.Stream.Progress says it is safe to call from another
+// goroutine at any time — and a fake that did not honour that would let a
+// racy real implementation pass every test.
+type stream struct {
+	ch chan provider.Item
+
+	mu   sync.Mutex
+	prog provider.Progress
+	err  error
+}
+
+func (s *stream) Items() <-chan provider.Item { return s.ch }
+
+func (s *stream) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+func (s *stream) Progress() provider.Progress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.prog
+}
+
+func (s *stream) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+func (s *stream) setTotal(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prog.Total, s.prog.TotalKnown = n, true
+}
+
+func (s *stream) advance() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prog.Seen++
+	s.prog.LastAt = time.Now()
+}
+
+var (
+	_ provider.Provider = (*Fake)(nil)
+	_ provider.Syncer   = (*Fake)(nil)
+	_ provider.Stream   = (*stream)(nil)
+)

--- a/internal/provider/providertest/manual.go
+++ b/internal/provider/providertest/manual.go
@@ -13,6 +13,7 @@ package providertest
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
@@ -141,18 +142,20 @@ func (m *Manual) Compose(e provider.Entry) (provider.Item, error) {
 	return it, nil
 }
 
-func trim(s string) string {
-	start, end := 0, len(s)
-	for start < end && isSpace(s[start]) {
-		start++
-	}
-	for end > start && isSpace(s[end-1]) {
-		end--
-	}
-	return s[start:end]
-}
-
-func isSpace(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
+// trim is strings.TrimSpace, which folds Unicode whitespace.
+//
+// It was a hand-rolled byte-wise ASCII loop, which is the same shape and the
+// same defect that provider.isBlank carried: a pasted title can contain
+// U+00A0 NO-BREAK SPACE or U+3000 IDEOGRAPHIC SPACE just as a pasted
+// credential can, and a whitespace-only title would then have been minted into
+// a real Item while the sibling credential path correctly refused it.
+//
+// This file is designated in the package comment as the reference
+// implementation the physical provider will be, so a defect here propagates
+// into shipped code rather than staying in a test double. That is exactly why
+// the credential-path fix had to be carried across rather than left as a
+// one-package repair.
+func trim(s string) string { return strings.TrimSpace(s) }
 
 // Manual implements Provider and Enterer. It does NOT implement Syncer, and
 // there is deliberately no assertion here that it does — the absence is the

--- a/internal/provider/providertest/manual.go
+++ b/internal/provider/providertest/manual.go
@@ -1,0 +1,163 @@
+// Package providertest holds provider implementations that reach no network,
+// so that every screen and every contract test can run with the machine in a
+// Faraday cage.
+//
+// It contains two things, and the distinction between them is the point:
+//
+//	Manual  — the shape a real hand-entry provider has. It is here rather than
+//	          in a provider package because Phase 1 builds no providers; it is
+//	          the reference implementation the physical provider will be, and
+//	          it is what proves the seam is not Steam-shaped.
+//	Fake    — a scriptable Syncer. It is a test double and nothing else.
+package providertest
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Manual is a provider whose items arrive because a person typed them.
+//
+// It is the case the store-provider seam was designed against first, and it is
+// the best available test of whether that seam is secretly Steam-shaped. Read
+// it and note what is absent: no credentials, no pagination, no rate limit, no
+// HTTP client, no Sync method, and no playtime. Every one of those absences is
+// a place a one-interface design would have forced this provider to lie.
+//
+// It implements [provider.Provider] and [provider.Enterer] and NOT
+// [provider.Syncer]. That is asserted at the bottom of this file, and a
+// contract test asserts the negative at run time — because the negative is the
+// decision, and a compiler cannot check the absence of an implementation.
+type Manual struct {
+	// NewRef mints a provider reference for a new entry.
+	//
+	// It is injected so a test gets deterministic refs. A real physical
+	// provider mints a UUID, which is why Z-08 never asks the player for an
+	// app ID: a cartridge has none, and requiring one would have been the
+	// first Steam-shaped assumption to reach a screen.
+	NewRef func() string
+
+	// Now supplies the clock. 06-data-seams.md §7 declines to make the clock
+	// a seam — a func field on the structs that need it is enough, and an
+	// interface for this is ceremony.
+	Now func() time.Time
+}
+
+// NewManual returns a Manual with deterministic test defaults.
+func NewManual() *Manual {
+	var n int
+	base := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	return &Manual{
+		NewRef: func() string { n++; return fmt.Sprintf("manual-%04d", n) },
+		Now:    func() time.Time { return base },
+	}
+}
+
+// ID returns the physical provider's identity.
+func (m *Manual) ID() provider.ID { return "physical" }
+
+// Display returns the player-facing name.
+//
+// A real implementation renders this through the catalogue, because "Physical
+// shelf" is a phrase rather than a brand. The literal here is a test double's,
+// and it is the one place in this repository a user-facing English string is
+// acceptable — nothing ships it.
+func (m *Manual) Display() string { return "Physical shelf" }
+
+// Capabilities declares what a shelf can and cannot know.
+//
+// Sync is false because there is nothing to fetch. Playtime and LastPlayed are
+// false because a cartridge has no telemetry — and that single fact is what
+// makes all four states manual for this provider, without status.Derive
+// containing a special case for it. OwnedSince is true because a player
+// entering a cartridge genuinely knows when they got it.
+func (m *Manual) Capabilities() provider.Capabilities {
+	return provider.Capabilities{
+		Sync:        false,
+		Manual:      true,
+		Playtime:    false,
+		LastPlayed:  false,
+		OwnedSince:  true,
+		Credentials: nil, // a shelf has no key
+	}
+}
+
+// Form returns the four fields Z-08 renders, of which two are required.
+func (m *Manual) Form() []provider.EntryField {
+	return []provider.EntryField{
+		{Key: "title", LabelKey: "entry.title.label", HelpKey: "entry.title.help", Kind: provider.FieldText, Required: true},
+		{Key: "platform", LabelKey: "entry.platform.label", HelpKey: "entry.platform.help", Kind: provider.FieldText, Required: true},
+		{
+			Key: "state", LabelKey: "entry.state.label", Kind: provider.FieldChoice,
+			Options: []provider.FieldOption{
+				{Value: "not_started", LabelKey: "state.not_started"},
+				{Value: "in_progress", LabelKey: "state.in_progress"},
+				{Value: "zerado", LabelKey: "state.zerado"},
+				{Value: "abandoned", LabelKey: "state.abandoned"},
+			},
+		},
+		{Key: "owned_since", LabelKey: "entry.owned_since.label", HelpKey: "entry.owned_since.help", Kind: provider.FieldDate},
+	}
+}
+
+// Compose turns a completed form into an item, minting the reference itself.
+//
+// It validates and does not write: the store is the only writer, and returning
+// an Item means hand entry travels the same upsert path a sync does. That
+// shared path is what makes a physical copy structurally the same kind of
+// thing as a Steam game rather than a flag on one.
+//
+// Note that it never sets PlaytimeMinutes, not even to zero. Capabilities says
+// this provider cannot report playtime, and a zero would be a number
+// status.Derive would treat as evidence.
+func (m *Manual) Compose(e provider.Entry) (provider.Item, error) {
+	title := trim(e["title"])
+	platform := trim(e["platform"])
+	if title == "" {
+		return provider.Item{}, fault.New(fault.KindMalformed, "physical.Compose",
+			fault.WithMessage("entry.title.required"))
+	}
+	if platform == "" {
+		return provider.Item{}, fault.New(fault.KindMalformed, "physical.Compose",
+			fault.WithMessage("entry.platform.required"))
+	}
+
+	it := provider.Item{
+		ProviderRef: m.NewRef(),
+		Title:       title,
+		Platform:    platform,
+	}
+	if s := trim(e["owned_since"]); s != "" {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return provider.Item{}, fault.New(fault.KindMalformed, "physical.Compose",
+				fault.WithMessage("entry.owned_since.unparsed"), fault.WithCause(err))
+		}
+		it.OwnedSince = &t
+	}
+	return it, nil
+}
+
+func trim(s string) string {
+	start, end := 0, len(s)
+	for start < end && isSpace(s[start]) {
+		start++
+	}
+	for end > start && isSpace(s[end-1]) {
+		end--
+	}
+	return s[start:end]
+}
+
+func isSpace(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
+
+// Manual implements Provider and Enterer. It does NOT implement Syncer, and
+// there is deliberately no assertion here that it does — the absence is the
+// design, and TestManualIsNotASyncer checks it at run time.
+var (
+	_ provider.Provider = (*Manual)(nil)
+	_ provider.Enterer  = (*Manual)(nil)
+)

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -16,6 +16,12 @@ import "sort"
 type Registry struct {
 	byID  map[ID]Provider
 	order []ID
+
+	// collisions records every ID registered more than once, at the moment it
+	// happens. After construction the evidence is gone — the later
+	// registration has overwritten the earlier one — so it cannot be
+	// recovered by inspecting byID afterwards.
+	collisions []ID
 }
 
 // NewRegistry builds a registry from providers, in the order given.
@@ -28,7 +34,9 @@ func NewRegistry(ps ...Provider) *Registry {
 	r := &Registry{byID: make(map[ID]Provider, len(ps))}
 	for _, p := range ps {
 		id := p.ID()
-		if _, seen := r.byID[id]; !seen {
+		if _, seen := r.byID[id]; seen {
+			r.collisions = append(r.collisions, id)
+		} else {
 			r.order = append(r.order, id)
 		}
 		r.byID[id] = p
@@ -80,13 +88,24 @@ func (r *Registry) Enterers() []Enterer {
 	return out
 }
 
-// Duplicates returns IDs that were registered more than once, sorted.
+// Duplicates returns IDs that appear more than once in ps, sorted.
+//
+// It is a package-level function and not a method, which is the correction to
+// a real defect rather than a stylistic preference. It used to hang off
+// *Registry and ignore its receiver, so r.Duplicates() — the natural call on
+// a method named that, attached to that — returned nil unconditionally
+// whatever the registry held. The only call that did anything was one that
+// re-passed the exact slice it had already given NewRegistry, which is a
+// coincidence and not an API.
 //
 // Registration is a start-up path with no screen behind it, so this is a
 // health check rather than an error return: a test asserts it is empty, and a
 // developer who registers Steam twice finds out in CI rather than by wondering
 // why their credential fields changed.
-func (r *Registry) Duplicates(ps ...Provider) []ID {
+//
+// [Registry.Collisions] is the question this one cannot answer — what a
+// particular registry actually swallowed.
+func Duplicates(ps ...Provider) []ID {
 	seen := map[ID]int{}
 	for _, p := range ps {
 		seen[p.ID()]++
@@ -97,6 +116,20 @@ func (r *Registry) Duplicates(ps ...Provider) []ID {
 			out = append(out, id)
 		}
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Collisions returns the IDs this registry was built with more than once,
+// sorted.
+//
+// It reports what [NewRegistry] actually observed, recorded at construction,
+// because after construction the evidence is gone: a later registration
+// overwrites the earlier one and the map cannot tell a replaced entry from a
+// single one. Recording it at the moment it happens is the only point at which
+// the fact exists.
+func (r *Registry) Collisions() []ID {
+	out := append([]ID(nil), r.collisions...)
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	return out
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -29,7 +29,9 @@ type Registry struct {
 // The order is display order — Z-02's picker and Z-09's groups both render it
 // — so it is the caller's to choose and is preserved rather than sorted.
 // A duplicate ID is a programming error and the later registration wins, which
-// is reported by [Registry.Duplicates] rather than silently tolerated.
+// is recorded and reported by [Registry.Collisions] rather than silently
+// tolerated. [Duplicates] answers the same question about a slice that has not
+// been registered yet.
 func NewRegistry(ps ...Provider) *Registry {
 	r := &Registry{byID: make(map[ID]Provider, len(ps))}
 	for _, p := range ps {

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,151 @@
+package provider
+
+import "sort"
+
+// Registry is the set of providers compiled into this binary.
+//
+// ADR-0001 D1 rejects a plugin system for stated reasons — four stores are
+// known, they ship in the binary, Go plugins do not cross-compile, and a
+// subprocess protocol is a network boundary in disguise. So the registry is
+// a map, and registration happens once at start-up.
+//
+// It is the one place above this package where looking a provider up by [ID]
+// is legitimate: a stored row carries a provider_id and something has to turn
+// that back into a Provider. Every *other* use of an ID above the seam is the
+// switch this design exists to remove.
+type Registry struct {
+	byID  map[ID]Provider
+	order []ID
+}
+
+// NewRegistry builds a registry from providers, in the order given.
+//
+// The order is display order — Z-02's picker and Z-09's groups both render it
+// — so it is the caller's to choose and is preserved rather than sorted.
+// A duplicate ID is a programming error and the later registration wins, which
+// is reported by [Registry.Duplicates] rather than silently tolerated.
+func NewRegistry(ps ...Provider) *Registry {
+	r := &Registry{byID: make(map[ID]Provider, len(ps))}
+	for _, p := range ps {
+		id := p.ID()
+		if _, seen := r.byID[id]; !seen {
+			r.order = append(r.order, id)
+		}
+		r.byID[id] = p
+	}
+	return r
+}
+
+// Get returns the provider with this ID.
+func (r *Registry) Get(id ID) (Provider, bool) {
+	p, ok := r.byID[id]
+	return p, ok
+}
+
+// All returns every registered provider in registration order.
+func (r *Registry) All() []Provider {
+	out := make([]Provider, 0, len(r.order))
+	for _, id := range r.order {
+		out = append(out, r.byID[id])
+	}
+	return out
+}
+
+// Syncers returns the providers that can fetch a library.
+//
+// This is what "sync everything" iterates, and it is why no caller needs to
+// know that physical exists in order to skip it.
+func (r *Registry) Syncers() []Syncer {
+	var out []Syncer
+	for _, p := range r.All() {
+		if s, ok := p.(Syncer); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Enterers returns the providers that accept hand-entered items.
+//
+// Z-01's "Add a game by hand" door is enabled when this is non-empty, and
+// Z-08's source is its single element in Phase 1 — a picker the day it has
+// two, with no other change.
+func (r *Registry) Enterers() []Enterer {
+	var out []Enterer
+	for _, p := range r.All() {
+		if e, ok := p.(Enterer); ok {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Duplicates returns IDs that were registered more than once, sorted.
+//
+// Registration is a start-up path with no screen behind it, so this is a
+// health check rather than an error return: a test asserts it is empty, and a
+// developer who registers Steam twice finds out in CI rather than by wondering
+// why their credential fields changed.
+func (r *Registry) Duplicates(ps ...Provider) []ID {
+	seen := map[ID]int{}
+	for _, p := range ps {
+		seen[p.ID()]++
+	}
+	var out []ID
+	for id, n := range seen {
+		if n > 1 {
+			out = append(out, id)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Check reports the ways a provider's declaration disagrees with the
+// interfaces it implements.
+//
+// [Capabilities] duplicates two facts the type system already carries — Sync
+// and Manual — because screens need them before they have a reason to type
+// assert, and because the offline classification is a property of the provider
+// rather than of a Go assertion. Duplicated facts drift, so this is the
+// assertion that they have not, and every provider is expected to be run
+// through it by a test.
+//
+// The returned strings are developer-facing and are not rendered anywhere.
+func Check(p Provider) []string {
+	var problems []string
+	c := p.Capabilities()
+
+	_, isSyncer := p.(Syncer)
+	if c.Sync != isSyncer {
+		problems = append(problems, "Capabilities.Sync disagrees with whether the provider implements Syncer")
+	}
+
+	_, isEnterer := p.(Enterer)
+	if c.Manual != isEnterer {
+		problems = append(problems, "Capabilities.Manual disagrees with whether the provider implements Enterer")
+	}
+
+	// A provider that cannot fetch has nothing to authenticate with. This is
+	// not pedantry: Z-02 exists only for providers with credential fields, so
+	// a non-syncing provider that declares one would put a screen in front of
+	// a player that could never do anything.
+	if !c.Sync && len(c.Credentials) > 0 {
+		problems = append(problems, "a provider that cannot Sync declares credential fields")
+	}
+
+	// A hand-entry provider that claims it can report playtime is claiming a
+	// telemetry source it does not have; the derivation would then treat a
+	// typed number as evidence.
+	if c.Manual && !c.Sync && c.Playtime {
+		problems = append(problems, "a hand-entry-only provider claims Playtime, which nothing could observe")
+	}
+
+	if p.ID() == "" {
+		problems = append(problems, "provider ID is empty")
+	}
+	if p.Display() == "" {
+		problems = append(problems, "provider Display is empty")
+	}
+	return problems
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -37,7 +37,14 @@ func NewRegistry(ps ...Provider) *Registry {
 	for _, p := range ps {
 		id := p.ID()
 		if _, seen := r.byID[id]; seen {
-			r.collisions = append(r.collisions, id)
+			// Recorded once per ID, not once per extra registration, so that
+			// this and [Duplicates] answer "which IDs collided" with the same
+			// multiplicity. An ID registered three times is one collision, and
+			// two functions disagreeing about that would be two answers to one
+			// question.
+			if !containsID(r.collisions, id) {
+				r.collisions = append(r.collisions, id)
+			}
 		} else {
 			r.order = append(r.order, id)
 		}
@@ -123,7 +130,7 @@ func Duplicates(ps ...Provider) []ID {
 }
 
 // Collisions returns the IDs this registry was built with more than once,
-// sorted.
+// sorted, each appearing once however many times it was registered.
 //
 // It reports what [NewRegistry] actually observed, recorded at construction,
 // because after construction the evidence is gone: a later registration
@@ -183,4 +190,14 @@ func Check(p Provider) []string {
 		problems = append(problems, "provider Display is empty")
 	}
 	return problems
+}
+
+// containsID reports whether ids holds x.
+func containsID(ids []ID, x ID) bool {
+	for _, id := range ids {
+		if id == x {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/stream.go
+++ b/internal/provider/stream.go
@@ -68,6 +68,28 @@ type Stream interface {
 //
 // It is a value, not a pointer, so a screen cannot hold a handle that changes
 // underneath it between two lines of a render function.
+//
+// # What it deliberately does not carry
+//
+// An earlier revision had a Batches field, documented as "written by the
+// consumer", for PARTIAL's copy — "The 138 that arrived are in your library" —
+// which is a claim about what was *written* and not about what was received.
+//
+// It could never have worked, and the interface's own shape is why: Stream is
+// read-only from the consumer's side, so nothing could have written it, and
+// the field could only ever have read zero. The screen would have rendered
+// "The 0 that arrived are in your library" — the exact sentence PARTIAL exists
+// to make true.
+//
+// The repair is not a setter on Stream. It is noticing that the written count
+// is not a property of the provider's stream at all: the provider cannot know
+// what the store committed, and a consumer-written field on a provider-owned
+// snapshot is a second writer to somebody else's value. The consumer already
+// accumulates store.BatchResult across batches and store.SyncRun records the
+// totals, so PARTIAL's copy reads those.
+//
+// Progress answers "how is the fetch going", which is the provider's question.
+// BatchResult answers "what did we keep", which is the store's.
 type Progress struct {
 	// Seen is how many items have been delivered so far.
 	Seen int
@@ -90,15 +112,6 @@ type Progress struct {
 	// alarming is a screen's judgement about a player's patience, not a
 	// provider's judgement about a socket.
 	LastAt time.Time
-
-	// Batches is how many upsert batches the consumer has committed.
-	//
-	// Written by the consumer rather than the provider, and present because
-	// PARTIAL's copy — "The 138 that arrived are in your library" — is a claim
-	// about what was *written*, not about what was received. A provider that
-	// delivered 138 items into a consumer that had committed 120 of them
-	// makes that sentence false by eighteen.
-	Batches int
 }
 
 // Determinate reports whether a progress bar can honestly be drawn.

--- a/internal/provider/stream.go
+++ b/internal/provider/stream.go
@@ -1,0 +1,122 @@
+package provider
+
+import "time"
+
+// Stream is a sync in flight.
+//
+// # Why a channel and not a slice
+//
+// 06-data-seams.md §2.5 gives three reasons and they are all about honesty:
+// Z-03 can show running counts on a 1,000-title library instead of an
+// indeterminate wait followed by a number; a cancel mid-sync leaves a valid
+// partial library rather than nothing; and memory stays bounded on a library
+// of any size. The cost — the store's upsert becomes transactional per batch
+// rather than per sync — is a known trade rather than a surprise.
+//
+// # Why a Stream and not a bare channel
+//
+// The spine's shape was Sync(ctx, c) (<-chan Item, error), which carries the
+// failure that is known before anything arrives and has nowhere to put the
+// failure that happens after. That second failure is the PARTIAL state — items
+// arrived, then the connection broke — and it is one of Z-03's four terminal
+// states, so it cannot be inexpressible.
+//
+// A Stream adds exactly two things to the channel: a terminal error readable
+// after the channel closes, which is the sql.Rows pattern, and a progress
+// snapshot, which is the thing a render loop needs and cannot get from a
+// channel at all.
+//
+// # The progress snapshot is why Z-03 has two components
+//
+// Z-03 §3.1 picks between a scanner (indeterminate) and a bar (determinate) by
+// whether the denominator is known. A channel of items cannot say "247 are
+// coming"; [Progress] can, and it is the only way the screen gets to draw a
+// bar rather than an apology.
+type Stream interface {
+	// Items returns the channel the provider writes to.
+	//
+	// It is closed exactly once, when the sync ends for any reason —
+	// completion, failure, or cancellation. A caller ranges over it and then
+	// reads [Stream.Err]; there is no other correct order.
+	Items() <-chan Item
+
+	// Err returns the terminal fault, or nil if the sync completed.
+	//
+	// It is valid only after Items() is closed. Calling it earlier is a
+	// programming error and an implementation may return anything; callers
+	// range first, always.
+	//
+	// A non-nil Err after items have already been delivered is the PARTIAL
+	// case: what arrived is kept, the sync_run records partial, and — this is
+	// the rule that matters — nothing may be tombstoned, because in a
+	// truncated stream "not returned" and "not reached" are indistinguishable
+	// (06 §2.4).
+	Err() error
+
+	// Progress returns a snapshot of how far the sync has got.
+	//
+	// It is safe to call from another goroutine at any time, including while
+	// the sync is running and after it has finished. That is a hard
+	// requirement rather than a convenience: the caller is a Bubble Tea render
+	// loop that will read it once per frame while the provider's goroutine
+	// writes it, and an implementation that does not make it race-free is a
+	// data race in the product's most-watched screen.
+	Progress() Progress
+}
+
+// Progress is a race-free snapshot of a sync in flight.
+//
+// It is a value, not a pointer, so a screen cannot hold a handle that changes
+// underneath it between two lines of a render function.
+type Progress struct {
+	// Seen is how many items have been delivered so far.
+	Seen int
+
+	// Total is how many the provider expects to deliver, and TotalKnown says
+	// whether that expectation exists yet.
+	//
+	// Two fields rather than a sentinel zero, because zero is a real total —
+	// it is the private-profile case — and a screen that reads 0 as "unknown"
+	// would draw an indeterminate scanner forever for a sync that has already
+	// truthfully finished.
+	Total      int
+	TotalKnown bool
+
+	// LastAt is when the most recent item arrived.
+	//
+	// It is here so the caller can implement Z-03's stalled state — ten
+	// seconds with no progress drops back to the scanner — without the
+	// provider having to know what "stalled" means. Whether a pause is
+	// alarming is a screen's judgement about a player's patience, not a
+	// provider's judgement about a socket.
+	LastAt time.Time
+
+	// Batches is how many upsert batches the consumer has committed.
+	//
+	// Written by the consumer rather than the provider, and present because
+	// PARTIAL's copy — "The 138 that arrived are in your library" — is a claim
+	// about what was *written*, not about what was received. A provider that
+	// delivered 138 items into a consumer that had committed 120 of them
+	// makes that sentence false by eighteen.
+	Batches int
+}
+
+// Determinate reports whether a progress bar can honestly be drawn.
+//
+// Z-03 §3.1's rule, in one place, so that two screens cannot disagree about
+// when the denominator counts as known.
+func (p Progress) Determinate() bool { return p.TotalKnown && p.Total > 0 }
+
+// Stalled reports whether nothing has arrived for at least d.
+//
+// A sync that has not yet delivered anything is not stalled — it is waiting,
+// which is Z-03's indeterminate state and already has its own component. The
+// distinction matters because "stalled" would otherwise be true for the whole
+// of a slow first round trip, and the screen would flip components for no
+// reason the player could see.
+func (p Progress) Stalled(now time.Time, d time.Duration) bool {
+	if p.Seen == 0 || p.LastAt.IsZero() {
+		return false
+	}
+	return now.Sub(p.LastAt) >= d
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,226 @@
+// Package status holds Zerado's four states and the one rule that decides
+// which of them a game is in.
+//
+// # State versus status
+//
+// 05-state-machine.md opens by drawing this distinction and keeping it:
+// **state** is what the player sees — the four values, the chip, the column,
+// the filter; **status** is what the machine stores and commands —
+// status_manual, SetStatus, Z-06 Set status. This package is named for the
+// machine's half because that is what it is: a stored value and a derivation
+// over it.
+//
+// # The four are ratified
+//
+// The values, their colours, glyphs, ASCII fallbacks and labels are settled in
+// the brand manual §4.3 and are not a design question here. What this package
+// owns is the model: one nullable manual value, one derivation when there is
+// none, and the invariant that a sync never writes the manual value.
+package status
+
+// Status is one of Zerado's four game states.
+//
+// It is a uint8 with an invalid zero value, deliberately. 05-state-machine.md
+// §1 requires that an uninitialised status can never be mistaken for "not
+// started", and a string type would make the empty string a plausible-looking
+// fifth value that renders as a blank chip. [Unknown] renders as nothing
+// because it is never persisted and never reaches a screen — the counts on the
+// summary row have to sum to the number shown (§7 rule 1), and a row that
+// cannot be classified would break that silently.
+type Status uint8
+
+const (
+	// Unknown is the zero value. It is never persisted and never rendered.
+	Unknown Status = iota
+
+	// NotStarted is the honest default: owned, and no evidence of play.
+	//
+	// It is also what [Derive] returns for a provider that cannot report
+	// playtime at all — a cartridge has no telemetry, and "not started" is
+	// the truthful thing to say about a game nothing can observe.
+	NotStarted
+
+	// InProgress is the one state a machine may ever assign on its own, and
+	// only from playtime the provider reported.
+	InProgress
+
+	// Zerado is the earned state — the moment the product exists to create.
+	//
+	// It is never automatic. 05-state-machine.md §4 records that as a product
+	// decision rather than a technical one: a player who is *told* they
+	// finished something has not finished it, they have been notified. Phase 2
+	// may suggest; only the player may set.
+	Zerado
+
+	// Abandoned is a choice, never an inference. Nothing about a save file
+	// distinguishes "stopped" from "busy this month".
+	Abandoned
+)
+
+// String returns the stored, machine-readable form.
+//
+// These are the values written to status_manual and read back from it, and
+// they are the values the CLI accepts and emits. They are API: renaming one
+// breaks every existing library file and every script. They are not labels —
+// the uppercase words a screen shows come from the catalogue, because
+// ADR-0001 D9 leaves no user-facing string in code.
+func (s Status) String() string {
+	switch s {
+	case NotStarted:
+		return "not_started"
+	case InProgress:
+		return "in_progress"
+	case Zerado:
+		return "zerado"
+	case Abandoned:
+		return "abandoned"
+	default:
+		return "unknown"
+	}
+}
+
+// Valid reports whether s is one of the four.
+func (s Status) Valid() bool { return s >= NotStarted && s <= Abandoned }
+
+// Parse converts the stored form back to a Status.
+//
+// ok is false for anything unrecognised, including the empty string. A caller
+// reading a NULL status_manual must not route it through Parse — nil and
+// "no opinion" are the same fact and are represented by a nil *Status, which
+// is the distinction 05 §5 requires so that "clear override" is expressible at
+// all.
+func Parse(s string) (Status, bool) {
+	switch s {
+	case "not_started":
+		return NotStarted, true
+	case "in_progress":
+		return InProgress, true
+	case "zerado":
+		return Zerado, true
+	case "abandoned":
+		return Abandoned, true
+	default:
+		return Unknown, false
+	}
+}
+
+// All returns the four states in ratified display order.
+//
+// The order is the order Z-06 lists them and the order the summary row counts
+// them, so it is part of the contract rather than a convenience. Returned as a
+// fresh slice so a caller cannot reorder the product's own vocabulary.
+func All() []Status { return []Status{NotStarted, InProgress, Zerado, Abandoned} }
+
+// Derive computes a status from what the provider reported, for a game whose
+// player has never expressed an opinion.
+//
+// It is the whole automatic half of the model, and it has exactly one
+// transition in it: NOT STARTED becomes IN PROGRESS when a provider that can
+// report playtime reports some.
+//
+// canReportPlaytime is Capabilities.Playtime, passed as a bool rather than as
+// the Capabilities struct so that this package does not import the provider
+// seam — the derivation is a rule about a number and a capability, not about a
+// provider, and keeping it importless is what lets the store, the CLI and the
+// screens all call it.
+//
+// The capability argument is the load-bearing one. For Steam, NOT STARTED and
+// IN PROGRESS are facts until the player overrides them. For physical, and for
+// any store whose API does not expose playtime, all four states are manual
+// always — the derivation has no input and returns the honest default. That is
+// precisely why physical is modelled as a provider with capabilities rather
+// than as an is_physical flag: a boolean would have forced this function to
+// special-case one value, and a capability makes it correct for every provider
+// that will ever exist, including the ones whose API does not exist yet.
+func Derive(playtimeMinutes int, canReportPlaytime bool) Status {
+	if !canReportPlaytime {
+		return NotStarted
+	}
+	if playtimeMinutes > 0 {
+		return InProgress
+	}
+	return NotStarted
+}
+
+// Effective resolves the model in one line:
+//
+//	effective = manual ?? derive(playtime, capability)
+//
+// manual is nil when the player has never expressed an opinion. A sync never
+// writes it: mark a game ZERADO, play it for three more hours, and the next
+// sync updates playtime and last-played and nothing else. That invariant is
+// what makes the product trustworthy, because the alternative is a background
+// job silently undoing the one action the product is named after.
+//
+// The result is never [Unknown] — an invalid manual value is ignored rather
+// than propagated, because a corrupt row must still render as a countable game
+// and §7 rule 1 requires the counts to sum.
+func Effective(manual *Status, playtimeMinutes int, canReportPlaytime bool) Status {
+	if manual != nil && manual.Valid() {
+		return *manual
+	}
+	return Derive(playtimeMinutes, canReportPlaytime)
+}
+
+// Counts is the pinned summary row: a total, and the four states beneath it.
+//
+// It is a struct rather than a map because 05 §7 rule 1 is that the four
+// counts always sum to the total, and a map has no shape that can be asserted.
+// [Counts.Sums] is the assertion, and it is cheap enough to run in a test for
+// every filter the product offers.
+type Counts struct {
+	// Total is the number of games in the set being described.
+	Total int
+
+	// NotStarted, InProgress, Zerado, Abandoned count by *effective* status,
+	// which is why this type lives beside the derivation and not beside the
+	// store.
+	NotStarted, InProgress, Zerado, Abandoned int
+}
+
+// Sums reports whether the four state counts add to Total.
+//
+// 05 §7 rule 1: "If the summary says 247 games, the four state counts add to
+// 247." A row that cannot be classified does not exist. This is the executable
+// form of that sentence, and a store implementation that cannot satisfy it has
+// a bug in its GROUP BY rather than an unusual library.
+func (c Counts) Sums() bool {
+	return c.NotStarted+c.InProgress+c.Zerado+c.Abandoned == c.Total
+}
+
+// Of returns the count for one status.
+func (c Counts) Of(s Status) int {
+	switch s {
+	case NotStarted:
+		return c.NotStarted
+	case InProgress:
+		return c.InProgress
+	case Zerado:
+		return c.Zerado
+	case Abandoned:
+		return c.Abandoned
+	default:
+		return 0
+	}
+}
+
+// Add increments the count for s and the total.
+//
+// Provided so that a store or a fake building Counts row by row cannot get the
+// total out of step with the parts — the only way [Counts.Sums] fails in
+// practice.
+func (c *Counts) Add(s Status) {
+	switch s {
+	case NotStarted:
+		c.NotStarted++
+	case InProgress:
+		c.InProgress++
+	case Zerado:
+		c.Zerado++
+	case Abandoned:
+		c.Abandoned++
+	default:
+		return
+	}
+	c.Total++
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,0 +1,145 @@
+package status_test
+
+import (
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// TestZeroValueIsNeverAState guards 05-state-machine.md §1: the zero value is
+// deliberately invalid so an uninitialised status can never be mistaken for
+// "not started".
+func TestZeroValueIsNeverAState(t *testing.T) {
+	var s status.Status
+	if s.Valid() {
+		t.Fatalf("the zero Status reports itself valid; an uninitialised value would render as a state")
+	}
+	if s != status.Unknown {
+		t.Fatalf("the zero Status is %v, expected Unknown", s)
+	}
+	for _, v := range status.All() {
+		if v == status.Unknown {
+			t.Fatalf("Unknown appears in All(); it is never rendered and never counted")
+		}
+	}
+}
+
+// TestDeriveIsCapabilityDriven is the test that physical copies are
+// first-class. A provider that cannot report playtime gets NOT STARTED
+// regardless of what number it was handed, so there is no path by which a
+// typed or defaulted zero becomes evidence.
+func TestDeriveIsCapabilityDriven(t *testing.T) {
+	cases := []struct {
+		name     string
+		minutes  int
+		playtime bool
+		want     status.Status
+	}{
+		{"a store that reports playtime, and there is some", 87 * 60, true, status.InProgress},
+		{"a store that reports playtime, and there is none", 0, true, status.NotStarted},
+		{"a cartridge, with a number that must be ignored", 9999, false, status.NotStarted},
+		{"a cartridge, with no number", 0, false, status.NotStarted},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := status.Derive(c.minutes, c.playtime); got != c.want {
+				t.Fatalf("Derive(%d, %v) = %v, want %v", c.minutes, c.playtime, got, c.want)
+			}
+		})
+	}
+}
+
+// TestNothingDerivesToZerado is 05-state-machine.md §4 as an executable rule:
+// ZERADO is never automatic, and no combination of provider-reported inputs
+// may produce it.
+func TestNothingDerivesToZerado(t *testing.T) {
+	for _, playtime := range []bool{true, false} {
+		for _, m := range []int{0, 1, 60, 100000} {
+			if got := status.Derive(m, playtime); got == status.Zerado || got == status.Abandoned {
+				t.Fatalf("Derive(%d, %v) = %v; only the player may set that state", m, playtime, got)
+			}
+		}
+	}
+}
+
+// TestManualWinsPermanently is the invariant that makes the product
+// trustworthy: a manual value survives any playtime a sync reports.
+func TestManualWinsPermanently(t *testing.T) {
+	z := status.Zerado
+	if got := status.Effective(&z, 300, true); got != status.Zerado {
+		t.Fatalf("playtime overrode a manual ZERADO: got %v", got)
+	}
+	n := status.NotStarted
+	if got := status.Effective(&n, 300, true); got != status.NotStarted {
+		t.Fatalf("an explicit NOT STARTED was overridden by playtime: got %v", got)
+	}
+}
+
+// TestClearingAnOverrideRederives is 05 §5's consequence, stated in the spec
+// as something the copy must be honest about: clearing on a game with playtime
+// makes it IN PROGRESS immediately, and choosing NOT STARTED explicitly is a
+// different action.
+func TestClearingAnOverrideRederives(t *testing.T) {
+	if got := status.Effective(nil, 300, true); got != status.InProgress {
+		t.Fatalf("cleared override with playtime = %v, want InProgress", got)
+	}
+	n := status.NotStarted
+	if status.Effective(&n, 300, true) == status.Effective(nil, 300, true) {
+		t.Fatal("setting NOT STARTED and clearing the override produced the same result; the model needs them distinct")
+	}
+}
+
+// TestEffectiveIsNeverUnknown guards §7 rule 1: every row must be countable,
+// so even a corrupt manual value falls back to the derivation.
+func TestEffectiveIsNeverUnknown(t *testing.T) {
+	bogus := status.Status(200)
+	if got := status.Effective(&bogus, 0, false); got != status.NotStarted {
+		t.Fatalf("a corrupt manual value produced %v; it must fall back to the derivation", got)
+	}
+	if !status.Effective(&bogus, 0, false).Valid() {
+		t.Fatal("Effective returned an invalid status")
+	}
+}
+
+// TestParseRoundTrips keeps the stored form stable. These strings are written
+// into every player's library file.
+func TestParseRoundTrips(t *testing.T) {
+	for _, s := range status.All() {
+		got, ok := status.Parse(s.String())
+		if !ok || got != s {
+			t.Fatalf("Parse(%q) = %v, %v; want %v, true", s.String(), got, ok, s)
+		}
+	}
+	if _, ok := status.Parse(""); ok {
+		t.Fatal("the empty string parsed as a status; NULL must be represented by a nil pointer, not a value")
+	}
+	if _, ok := status.Parse("finished"); ok {
+		t.Fatal("an unknown token parsed as a status")
+	}
+}
+
+// TestCountsAlwaysSum is 05 §7 rule 1: if the summary says 247 games, the four
+// state counts add to 247.
+func TestCountsAlwaysSum(t *testing.T) {
+	var c status.Counts
+	for i := 0; i < 10; i++ {
+		c.Add(status.NotStarted)
+	}
+	for i := 0; i < 3; i++ {
+		c.Add(status.Zerado)
+	}
+	c.Add(status.Abandoned)
+	if !c.Sums() {
+		t.Fatalf("counts do not sum: %+v", c)
+	}
+	if c.Total != 14 {
+		t.Fatalf("Total = %d, want 14", c.Total)
+	}
+
+	// An unclassifiable row must not increment the total either, or the
+	// summary would claim a game the four counts cannot account for.
+	c.Add(status.Unknown)
+	if !c.Sums() || c.Total != 14 {
+		t.Fatalf("an Unknown row disturbed the summary: %+v", c)
+	}
+}

--- a/internal/store/contract_test.go
+++ b/internal/store/contract_test.go
@@ -1,0 +1,321 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider/providertest"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+	"github.com/JustCode-CruzAlex/Zerado/internal/store"
+	"github.com/JustCode-CruzAlex/Zerado/internal/store/storetest"
+)
+
+var at = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+func seeded(t *testing.T) (*storetest.Fake, context.Context) {
+	t.Helper()
+	f := storetest.New()
+	f.Playtime["steam"] = true
+	f.Playtime["physical"] = false
+	ctx := context.Background()
+
+	m87, m0 := 87*60, 0
+	_, err := f.UpsertBatch(ctx, "steam", []provider.Item{
+		{ProviderRef: "1086940", Title: "Baldur's Gate 3", Platform: "PC", PlaytimeMinutes: &m87},
+		{ProviderRef: "774361", Title: "Blasphemous", Platform: "PC", PlaytimeMinutes: &m0},
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return f, ctx
+}
+
+// TestASyncNeverChangesAStatusThePlayerSet is the invariant that makes the
+// product trustworthy. Mark a game ZERADO, play three more hours, sync: the
+// playtime moves and the state does not.
+func TestASyncNeverChangesAStatusThePlayerSet(t *testing.T) {
+	f, ctx := seeded(t)
+	games, _ := f.Games(ctx, library.Query{})
+	id := games[0].ID
+
+	z := status.Zerado
+	if err := f.SetStatus(ctx, id, &z); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+
+	more := 300 * 60
+	if _, err := f.UpsertBatch(ctx, "steam", []provider.Item{
+		{ProviderRef: games[0].ProviderRef, Title: games[0].Title, Platform: games[0].Platform, PlaytimeMinutes: &more},
+	}); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+
+	g, _ := f.Game(ctx, id)
+	if g.Status(true) != status.Zerado {
+		t.Fatalf("a sync changed the player's status to %v; the one action the product is named after was undone by a background job", g.Status(true))
+	}
+	if pt, _ := g.Playtime(); pt != more {
+		t.Fatalf("playtime = %d, want %d — the sync must still update provider facts", pt, more)
+	}
+}
+
+// TestClearingAnOverrideIsADistinctAction and is stamped, because Phase 4's
+// last-write-wins needs a timestamp for it to compare.
+func TestClearingAnOverrideIsADistinctAction(t *testing.T) {
+	f, ctx := seeded(t)
+	games, _ := f.Games(ctx, library.Query{})
+	id := games[0].ID
+
+	z := status.Zerado
+	_ = f.SetStatus(ctx, id, &z)
+	if err := f.SetStatus(ctx, id, nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	g, _ := f.Game(ctx, id)
+	if g.Overridden() {
+		t.Fatal("the override survived a clear")
+	}
+	if g.StatusChangedAt == nil {
+		t.Fatal("clearing an override left no timestamp; a Phase 4 merge could not resolve it")
+	}
+	if g.Status(true) != status.InProgress {
+		t.Fatalf("after clearing, the derivation gave %v; 05 §5 requires it to re-derive to IN PROGRESS", g.Status(true))
+	}
+}
+
+// TestOnlyAnOkRunMayTombstone is the guard that protects a player's own work
+// from a truncated stream. In a partial sync, "not returned" and "not reached"
+// are indistinguishable.
+func TestOnlyAnOkRunMayTombstone(t *testing.T) {
+	for _, s := range []store.RunStatus{store.RunPartial, store.RunFailed, store.RunCancelled} {
+		t.Run(s.String(), func(t *testing.T) {
+			f, ctx := seeded(t)
+			run, _ := f.StartRun(ctx, "steam", at)
+			_ = f.FinishRun(ctx, run, store.RunResult{FinishedAt: at, Status: s})
+
+			_, err := f.ReconcileAbsence(ctx, run, []string{"1086940"})
+			if err == nil {
+				t.Fatalf("a %s run was allowed to tombstone; a player's finished game would vanish because a stream broke", s)
+			}
+			if !fault.Is(err, fault.KindPrecondition) {
+				t.Fatalf("got %v, want KindPrecondition", fault.KindOf(err))
+			}
+			games, _ := f.Games(ctx, library.Query{})
+			for _, g := range games {
+				if g.Absent() {
+					t.Fatal("a row was marked absent despite the refusal")
+				}
+			}
+		})
+	}
+}
+
+// TestAbsenceIsReversibleAndNeverADeletion walks 06 §2.4 end to end: a
+// complete sync that stops returning a game marks it absent, the row stays and
+// is findable by filter, and the moment it comes back the flag clears
+// silently.
+func TestAbsenceIsReversibleAndNeverADeletion(t *testing.T) {
+	f, ctx := seeded(t)
+
+	run, _ := f.StartRun(ctx, "steam", at)
+	_ = f.FinishRun(ctx, run, store.RunResult{FinishedAt: at, Status: store.RunOK})
+	a, err := f.ReconcileAbsence(ctx, run, []string{"1086940"})
+	if err != nil {
+		t.Fatalf("ReconcileAbsence: %v", err)
+	}
+	if a.MarkedAbsent != 1 {
+		t.Fatalf("MarkedAbsent = %d, want 1", a.MarkedAbsent)
+	}
+
+	shown, _ := f.Games(ctx, library.Query{})
+	if len(shown) != 1 {
+		t.Fatalf("the default view shows %d rows, want 1 — absent rows are excluded from it", len(shown))
+	}
+	absent, _ := f.Games(ctx, library.Query{Presence: library.AbsentOnly})
+	if len(absent) != 1 {
+		t.Fatalf("the absent facet found %d rows, want 1 — the row must remain findable by filter", len(absent))
+	}
+	all, _ := f.Games(ctx, library.Query{Presence: library.Either})
+	if len(all) != 2 {
+		t.Fatalf("nothing was deleted, so Either must return 2, got %d", len(all))
+	}
+
+	m := 0
+	if _, err := f.UpsertBatch(ctx, "steam", []provider.Item{
+		{ProviderRef: "774361", Title: "Blasphemous", Platform: "PC", PlaytimeMinutes: &m},
+	}); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	back, _ := f.Games(ctx, library.Query{})
+	if len(back) != 2 {
+		t.Fatalf("the returning game was not restored to the default view: %d rows", len(back))
+	}
+}
+
+// TestCountsDescribeTheFilteredSet is 05 §7 rule 2: showing whole-library
+// counts above a filtered list is the most common way a list view lies.
+func TestCountsDescribeTheFilteredSet(t *testing.T) {
+	f, ctx := seeded(t)
+
+	manual := providertest.NewManual()
+	it, _ := manual.Compose(provider.Entry{"title": "Chrono Trigger", "platform": "SNES"})
+	if _, err := f.AddManual(ctx, manual.ID(), it, nil); err != nil {
+		t.Fatalf("AddManual: %v", err)
+	}
+
+	whole, _ := f.Counts(ctx, library.Query{})
+	if whole.Total != 3 || !whole.Sums() {
+		t.Fatalf("whole-library counts = %+v", whole)
+	}
+
+	q := library.Query{Sources: []provider.ID{"physical"}}
+	filtered, _ := f.Counts(ctx, q)
+	if filtered.Total != 1 {
+		t.Fatalf("filtered Total = %d, want 1", filtered.Total)
+	}
+	if !filtered.Sums() {
+		t.Fatalf("filtered counts do not sum: %+v", filtered)
+	}
+
+	rows, _ := f.Games(ctx, q)
+	if len(rows) != filtered.Total {
+		t.Fatalf("the list shows %d rows and the summary claims %d; they were built from the same Query and must agree", len(rows), filtered.Total)
+	}
+}
+
+// TestPagingDoesNotShrinkTheSummary: the scroll-position row says "4–15 of
+// 247", so the summary describes the filtered set and not the visible page.
+func TestPagingDoesNotShrinkTheSummary(t *testing.T) {
+	f, ctx := seeded(t)
+	q := library.Query{Limit: 1}
+	rows, _ := f.Games(ctx, q)
+	counts, _ := f.Counts(ctx, q)
+	if len(rows) != 1 {
+		t.Fatalf("Limit was ignored: %d rows", len(rows))
+	}
+	if counts.Total != 2 {
+		t.Fatalf("Counts honoured Limit: Total = %d, want 2", counts.Total)
+	}
+}
+
+// TestAHandEnteredGameIsNotSecondClass: it is the same type on the same path,
+// it derives correctly with no special case, and its states are all the
+// player's.
+func TestAHandEnteredGameIsNotSecondClass(t *testing.T) {
+	f, ctx := seeded(t)
+	manual := providertest.NewManual()
+	it, _ := manual.Compose(provider.Entry{"title": "Chrono Trigger", "platform": "SNES"})
+	id, err := f.AddManual(ctx, manual.ID(), it, nil)
+	if err != nil {
+		t.Fatalf("AddManual: %v", err)
+	}
+	g, _ := f.Game(ctx, id)
+	if g.Status(f.Playtime[g.Provider]) != status.NotStarted {
+		t.Fatalf("a cartridge derived to %v", g.Status(false))
+	}
+	if _, reported := g.Playtime(); reported {
+		t.Fatal("a cartridge reported a playtime")
+	}
+
+	z := status.Zerado
+	if err := f.SetStatus(ctx, id, &z); err != nil {
+		t.Fatalf("a cartridge could not be marked zerado: %v", err)
+	}
+	rows, _ := f.Games(ctx, library.Query{States: []status.Status{status.Zerado}})
+	if len(rows) != 1 || rows[0].ID != id {
+		t.Fatalf("the state filter did not find the hand-entered game: %v", rows)
+	}
+}
+
+// TestUpsertCountsAreHonest, because Z-03's DONE line states all three and
+// they must add up to what was seen.
+func TestUpsertCountsAreHonest(t *testing.T) {
+	f, ctx := seeded(t)
+	m := 0
+	res, _ := f.UpsertBatch(ctx, "steam", []provider.Item{
+		{ProviderRef: "774361", Title: "Blasphemous", Platform: "PC", PlaytimeMinutes: &m},      // unchanged
+		{ProviderRef: "1086940", Title: "Baldur's Gate 3", Platform: "PC", PlaytimeMinutes: &m}, // changed
+		{ProviderRef: "413150", Title: "Stardew Valley", Platform: "PC", PlaytimeMinutes: &m},   // new
+	})
+	if res.New != 1 || res.Changed != 1 || res.Unchanged != 1 {
+		t.Fatalf("BatchResult = %+v, want one of each", res)
+	}
+	if res.Total() != 3 {
+		t.Fatalf("Total = %d, want 3", res.Total())
+	}
+}
+
+// TestAnEmptyBatchIsANoOp: the caller that classified a zero-item sync as a
+// refusal must never reach here, and the belt-and-braces case is harmless.
+func TestAnEmptyBatchIsANoOp(t *testing.T) {
+	f, ctx := seeded(t)
+	res, err := f.UpsertBatch(ctx, "steam", nil)
+	if err != nil {
+		t.Fatalf("UpsertBatch(nil) = %v", err)
+	}
+	if res.Total() != 0 {
+		t.Fatalf("an empty batch reported %+v", res)
+	}
+	rows, _ := f.Games(ctx, library.Query{Presence: library.Either})
+	if len(rows) != 2 {
+		t.Fatalf("an empty batch changed the library: %d rows", len(rows))
+	}
+}
+
+// TestNothingHasEverBeenSynced: LastRun returns nil rather than a zero value,
+// so Z-03 renders "Nothing has ever been synced." instead of a fabricated age.
+func TestNothingHasEverBeenSynced(t *testing.T) {
+	f, ctx := seeded(t)
+	run, err := f.LastRun(ctx, "steam")
+	if err != nil {
+		t.Fatalf("LastRun: %v", err)
+	}
+	if run != nil {
+		t.Fatal("LastRun invented a run")
+	}
+}
+
+// TestStatusForFaultJoinsTheTaxonomyToTheHistory: the same transport failure
+// is PARTIAL if items had arrived and FAILED if none had, and Z-03's copy for
+// those two is completely different.
+func TestStatusForFaultJoinsTheTaxonomyToTheHistory(t *testing.T) {
+	unreachable := fault.New(fault.KindUnreachable, "steam.Sync")
+	if got := store.StatusForFault(unreachable, true); got != store.RunPartial {
+		t.Fatalf("with items delivered: %v, want partial", got)
+	}
+	if got := store.StatusForFault(unreachable, false); got != store.RunFailed {
+		t.Fatalf("with nothing delivered: %v, want failed", got)
+	}
+	if got := store.StatusForFault(fault.New(fault.KindCancelled, "steam.Sync"), true); got != store.RunCancelled {
+		t.Fatalf("a cancel: %v, want cancelled", got)
+	}
+	if got := store.StatusForFault(nil, true); got != store.RunOK {
+		t.Fatalf("success: %v, want ok", got)
+	}
+	if !store.RunOK.MayTombstone() {
+		t.Fatal("an ok run cannot tombstone")
+	}
+	for _, s := range []store.RunStatus{store.RunRunning, store.RunPartial, store.RunFailed, store.RunCancelled} {
+		if s.MayTombstone() {
+			t.Fatalf("%v may tombstone", s)
+		}
+	}
+}
+
+// TestDisconnectDoesNotTouchTheLibrary: disconnecting Steam is not a statement
+// about what the player owns, and the rows carry the player's own work.
+func TestDisconnectDoesNotTouchTheLibrary(t *testing.T) {
+	f, ctx := seeded(t)
+	_ = f.SaveConnection(ctx, "steam", "76561198012345678", at)
+	if err := f.DeleteConnection(ctx, "steam"); err != nil {
+		t.Fatalf("DeleteConnection: %v", err)
+	}
+	rows, _ := f.Games(ctx, library.Query{Presence: library.Either})
+	if len(rows) != 2 {
+		t.Fatalf("disconnecting removed rows: %d left", len(rows))
+	}
+}

--- a/internal/store/run.go
+++ b/internal/store/run.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// RunID identifies one sync run.
+type RunID int64
+
+// RunStatus is how a sync ended.
+//
+// Four values, and they are the four Z-03 renders as terminal states. The set
+// is closed because each one has different consequences for what may happen
+// next: only ok may tombstone, ok and partial both leave a valid library, and
+// failed leaves it untouched.
+type RunStatus uint8
+
+const (
+	// RunRunning is a run that has been opened and not closed.
+	//
+	// It is not one of Z-03's terminal states; it is what a row looks like
+	// between StartRun and FinishRun, and what it looks like forever if the
+	// process was killed. A run found in this state at start-up was killed,
+	// which the ERD distinguishes from cancelled by finished_at being null.
+	RunRunning RunStatus = iota
+
+	// RunOK is a complete, successful sync. It is the only status that
+	// permits absence reconciliation.
+	RunOK
+
+	// RunPartial is items arrived, then the stream errored. The library is
+	// valid and incomplete.
+	RunPartial
+
+	// RunFailed is nothing arrived. The library is untouched, which is what
+	// lets the copy say "Your library is unchanged — nothing was lost."
+	RunFailed
+
+	// RunCancelled is the player stopped it. What arrived is kept, and none
+	// of it is an error.
+	RunCancelled
+)
+
+// String returns the stored, machine-readable form. These values are written
+// to the database and emitted by the CLI, so they are API.
+func (s RunStatus) String() string {
+	switch s {
+	case RunOK:
+		return "ok"
+	case RunPartial:
+		return "partial"
+	case RunFailed:
+		return "failed"
+	case RunCancelled:
+		return "cancelled"
+	default:
+		return "running"
+	}
+}
+
+// MayTombstone reports whether a run in this status is allowed to mark rows
+// absent.
+//
+// Exactly one status may. This is the executable form of 06-data-seams.md
+// §2.4's guard, and it is a method here rather than a condition inside a store
+// implementation so that a fake and a real store cannot disagree about it.
+func (s RunStatus) MayTombstone() bool { return s == RunOK }
+
+// StatusForFault maps a terminal fault onto the run status it produces.
+//
+// It is the join between the error taxonomy and the sync history, and it lives
+// here so that the two cannot drift. sawItems distinguishes the two cases a
+// fault alone cannot: the same transport failure is PARTIAL if items had
+// already arrived and FAILED if none had, and Z-03's copy for those two is
+// completely different — one says what was saved, the other says the library
+// is unchanged.
+func StatusForFault(err error, sawItems bool) RunStatus {
+	switch {
+	case err == nil:
+		return RunOK
+	case fault.Is(err, fault.KindCancelled):
+		return RunCancelled
+	case sawItems:
+		return RunPartial
+	default:
+		return RunFailed
+	}
+}
+
+// SyncRun is one recorded sync.
+//
+// partial exists as a status because a cancelled or truncated sync leaves a
+// valid library, and recording it is what lets Z-04 say "synced 3 days ago,
+// partially" instead of implying the library is complete.
+type SyncRun struct {
+	ID       RunID
+	Provider provider.ID
+
+	StartedAt time.Time
+
+	// FinishedAt is nil for a run that was never closed — the process was
+	// killed. That is a different fact from cancelled, and the ERD keeps them
+	// apart on purpose.
+	FinishedAt *time.Time
+
+	Status RunStatus
+
+	// Seen, New, Changed, Unchanged are what Z-03's DONE line reports:
+	// "12 new. 4 changed. 231 unchanged."
+	//
+	// Unchanged is stored rather than derived because it is stated on screen
+	// and because Seen minus New minus Changed is only equal to it when
+	// nothing was skipped, which is not true of a partial run.
+	Seen, New, Changed, Unchanged int
+
+	// FaultKind is the classified failure, or KindUnknown for a run that did
+	// not fail.
+	//
+	// The classification is stored, not a message and not a stack trace: the
+	// message is a catalogue key rendered at read time, so a library synced in
+	// English and read in Portuguese reports its history in Portuguese.
+	FaultKind fault.Kind
+}
+
+// Age returns how long ago the run finished, for the degrade banner's
+// "Last synced 3 days ago".
+//
+// An unfinished run has no age, which the caller must render as unknown rather
+// than as zero — Z-03 §8.1's rule that a missing previous run reads "Nothing
+// has ever been synced." rather than a fabricated duration.
+func (r SyncRun) Age(now time.Time) (time.Duration, bool) {
+	if r.FinishedAt == nil {
+		return 0, false
+	}
+	if d := now.Sub(*r.FinishedAt); d > 0 {
+		return d, true
+	}
+	return 0, true
+}
+
+// RunResult is what FinishRun records.
+type RunResult struct {
+	FinishedAt time.Time
+	Status     RunStatus
+	Seen       int
+	New        int
+	Changed    int
+	Unchanged  int
+	FaultKind  fault.Kind
+}
+
+// BatchResult is what one UpsertBatch changed.
+//
+// The three counts are summed across batches to produce Z-03's DONE line, and
+// they are returned per batch rather than accumulated by the store because the
+// store does not know when a sync has ended — only the caller that owns the
+// stream does.
+type BatchResult struct {
+	New       int
+	Changed   int
+	Unchanged int
+}
+
+// Add accumulates another batch's result.
+func (b *BatchResult) Add(o BatchResult) {
+	b.New += o.New
+	b.Changed += o.Changed
+	b.Unchanged += o.Unchanged
+}
+
+// Total returns how many rows the batch touched.
+func (b BatchResult) Total() int { return b.New + b.Changed + b.Unchanged }
+
+// Absence is what one reconciliation changed.
+//
+// Returned rather than silent because the two numbers have opposite screen
+// treatments: rows that came back are cleared silently with no notice (06 §2.4
+// is explicit about that), while rows that went absent are the reason Z-05
+// grows an "absent since" line. A caller that cannot tell them apart cannot
+// honour either rule.
+type Absence struct {
+	// MarkedAbsent is how many rows the run stopped returning.
+	MarkedAbsent int
+
+	// Returned is how many previously-absent rows came back.
+	Returned int
+}
+
+// Connection is a provider the player has connected.
+type Connection struct {
+	Provider provider.ID
+
+	// AccountRef is an identifier, never a secret — the Steam ID that Z-02
+	// shows back as "Connected as 76561198012345678".
+	AccountRef string
+
+	ConnectedAt time.Time
+
+	// LastSyncAt and LastSyncStatus are what the degrade banner reads to say
+	// "3 days ago", and nil when nothing has ever been synced.
+	LastSyncAt     *time.Time
+	LastSyncStatus RunStatus
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,242 @@
+// Package store is the repository seam: the only thing in Zerado that knows a
+// database exists.
+//
+// # The rule the whole architecture rests on
+//
+// A screen never talks to a provider. A provider never talks to a screen.
+// Between them sits this seam: a sync writes here, screens read from here, and
+// nothing renders from a network response, ever (06-data-seams.md §1).
+//
+// Three properties fall out of that, and each is a published promise:
+//
+//   - the offline contract is structural — a screen that only reads local
+//     state works offline because it cannot do anything else;
+//   - a failed sync cannot break a screen, only leave it stale, and stale is a
+//     state the design system has a banner for;
+//   - "no telemetry running in the background" is provable by inspection,
+//     because there is exactly one place network I/O can originate and it is
+//     not here.
+//
+// # There is no freshness parameter on any read, and that is deliberate
+//
+// The obvious way to express staleness in an API is a policy argument —
+// CachedOnly, PreferCached, ForceFresh. This interface has none, because a
+// read here cannot reach the network under any policy. What a caller gets is
+// what is local, stamped with when it was observed ([aged.Value]), and the
+// only way to make it fresher is an explicit sync, which is an action with a
+// screen and a key behind it.
+//
+// That absence is the offline contract expressed in the signatures. A
+// ForceFresh option would be a hole through which a render path could start a
+// network request, and 07 §7.3's grep rule — no net/http outside the provider
+// packages — would then be guarding a door with a window next to it.
+//
+// # SQL never leaves this package
+//
+// The interface below takes domain types and returns domain types. It exposes
+// no query builder, no expression, no transaction handle and no rows cursor. A
+// caller cannot construct SQL through it, which is the house rule and also
+// what makes the Phase 4 sync engine attachable at this boundary without
+// touching a screen.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/pricing"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+)
+
+// Store is the data-access interface. Every read a screen performs and every
+// write a command performs goes through it.
+//
+// # Context on everything
+//
+// Every method takes a context, including the ones that will always be
+// microseconds against a local file. Two reasons, and neither is speculative:
+// a filter that re-runs on every keystroke must be abandonable when the next
+// keystroke arrives, and a Phase 4 implementation of this same interface will
+// be doing I/O that genuinely blocks. An interface that has to grow contexts
+// later grows them in every caller at once.
+//
+// # Reads never mutate, writes never render
+//
+// The split below is not cosmetic. A read may be called from a render path and
+// must not write; a write is called from a command and returns what the screen
+// needs to say what happened.
+type Store interface {
+	// ---- Reads: everything a screen ever calls. ----
+
+	// Games returns the games matching q, ordered by sort title, ascending.
+	//
+	// The order is fixed rather than a parameter because Phase 1 has no sort
+	// control (07 §2) and an order argument would be that control's back end.
+	//
+	// Rows with MergedInto set are never returned, in any query. A merged row
+	// is not a row the player has; it is a tombstone that exists so Phase 4
+	// never has to rewrite a key.
+	Games(ctx context.Context, q library.Query) ([]library.Game, error)
+
+	// Game returns one game by local id.
+	//
+	// A missing id is fault.KindNotFound, which on this seam is a real defect
+	// — a screen asked for an id it was handed — rather than the routine
+	// absence it is on the metadata seam.
+	Game(ctx context.Context, id library.GameID) (library.Game, error)
+
+	// Counts returns the pinned summary for the same set Games would return.
+	//
+	// It takes the same Query for a reason that is a rule rather than a
+	// convenience: 05-state-machine.md §7 rule 2 forbids showing whole-library
+	// counts above a filtered list, which is the most common way a list view
+	// lies. Sharing the argument makes the two impossible to disagree.
+	//
+	// Limit and Offset are ignored here: the summary describes the filtered
+	// set, not the visible page.
+	//
+	// The four state counts must sum to Total — status.Counts.Sums is the
+	// assertion, and a store that cannot satisfy it has a bug in its grouping
+	// rather than an unusual library.
+	Counts(ctx context.Context, q library.Query) (status.Counts, error)
+
+	// Connections returns every provider the player has connected.
+	Connections(ctx context.Context) ([]Connection, error)
+
+	// LastRun returns the most recent sync run for a provider, or nil when
+	// there has never been one.
+	//
+	// The nil case is load-bearing rather than an edge: Z-03 §8.1 renders
+	// "Nothing has ever been synced." instead of a fabricated age, and a
+	// zero-valued SyncRun would make that fabrication the default.
+	LastRun(ctx context.Context, p provider.ID) (*SyncRun, error)
+
+	// Setting reads one setting. ok is false when the key has never been set,
+	// which is distinct from a key set to the empty string — Z-09 has dials
+	// whose "unset" and "off" are different.
+	Setting(ctx context.Context, key string) (value string, ok bool, err error)
+
+	// Metadata returns the cached enrichment for a game, stamped with when it
+	// was observed at its source.
+	//
+	// Phase 2 fills this; Phase 1 implementations return ok=false. It is on
+	// the Phase 1 interface because the alternative is a Phase 2 interface
+	// change in a seam that eleven screens read, for a method whose Phase 1
+	// implementation is one line.
+	//
+	// ok=false is the designed no-metadata state (06 §3.1), not an error. A
+	// hand-added cartridge no source has ever heard of is the normal case for
+	// a shelf, and it renders a composition rather than a banner.
+	Metadata(ctx context.Context, id library.GameID) (aged.Value[metadata.Metadata], bool, error)
+
+	// Quote returns the last known price for a game in a currency, stamped.
+	//
+	// Phase 3 fills this. The stamp is not optional and is not droppable: 07
+	// §4 forbids rendering a price without its age, and returning an
+	// aged.Value is how that becomes structurally true rather than a rule
+	// somebody has to remember at 1am while tidying a layout.
+	Quote(ctx context.Context, id library.GameID, cur pricing.Currency) (aged.Value[pricing.Quote], bool, error)
+
+	// ---- Writes: everything a command ever calls. ----
+
+	// SetStatus sets or clears the player's manual status.
+	//
+	// A nil s clears the override, which is a different action from setting
+	// NotStarted and both are needed: clearing on a game with playtime makes
+	// it IN PROGRESS immediately, while choosing NOT STARTED stores a manual
+	// value that sticks (05 §5). A single non-nullable parameter cannot
+	// express the difference, which is why this takes a pointer.
+	//
+	// The store stamps status_changed_at on every change, including a clear.
+	// It is the timestamp that decides a Phase 4 conflict, and a clear is a
+	// change the player made.
+	SetStatus(ctx context.Context, id library.GameID, s *status.Status) error
+
+	// UpsertBatch writes one batch of a provider's items and reports what
+	// changed.
+	//
+	// Batched rather than per-sync because Sync streams: the trade is named in
+	// 06 §2.5 and it is what makes a cancelled sync leave a valid partial
+	// library rather than nothing.
+	//
+	// It never writes StatusManual or StatusChangedAt. That is the invariant
+	// behind "a sync never changes a status the player set", and it belongs
+	// here rather than in a provider because the store is the only writer and
+	// therefore the only place it can be guaranteed.
+	//
+	// An empty batch is a no-op returning a zero BatchResult, not an error.
+	// The caller that has just classified a zero-item sync as a refusal
+	// (fault.KindEmpty) must not reach here at all, and this makes the
+	// belt-and-braces case harmless.
+	UpsertBatch(ctx context.Context, p provider.ID, items []provider.Item) (BatchResult, error)
+
+	// AddManual writes one hand-entered item and returns its new local id.
+	//
+	// It takes a provider.Item rather than a bespoke struct because that is
+	// the point of the Enterer seam: hand entry produces the same value a sync
+	// does and travels the same path. The provider has already minted the ref.
+	AddManual(ctx context.Context, p provider.ID, item provider.Item, s *status.Status) (library.GameID, error)
+
+	// StartRun opens a sync run and returns its id.
+	//
+	// The run is opened before any item is written, so that a process killed
+	// mid-sync leaves a run with a null finished_at — which the ERD names as
+	// the difference between "killed" and "cancelled cleanly", and which the
+	// next start-up can report honestly rather than inventing.
+	StartRun(ctx context.Context, p provider.ID, startedAt time.Time) (RunID, error)
+
+	// FinishRun closes a run with its terminal status and counts.
+	FinishRun(ctx context.Context, id RunID, r RunResult) error
+
+	// ReconcileAbsence tombstones the rows a completed sync did not return.
+	//
+	// seen is every ProviderRef the run delivered. Rows for this provider that
+	// are not in seen get absent_since set; rows in seen that carried
+	// absent_since have it cleared, silently and with no notice (06 §2.4).
+	//
+	// It takes a RunID rather than a ProviderID, and that is the guard rather
+	// than a stylistic choice. Only a sync whose status is ok may tombstone
+	// anything: in a truncated stream "not returned" and "not reached" are
+	// indistinguishable, so a partial, failed or cancelled run must not be
+	// allowed to conclude that a game is gone. An implementation MUST return
+	// fault.KindPrecondition when the named run is unfinished or its status is
+	// not ok.
+	//
+	// Passing a provider id would have made the illegal call spellable, and
+	// the illegal call deletes the evidence that a player finished a game.
+	// Nothing is ever deleted here: absence is reversible and deletion is not,
+	// and 06 §2.4 chooses the reversible option precisely because the evidence
+	// for the other one is so weak.
+	ReconcileAbsence(ctx context.Context, run RunID, seen []string) (Absence, error)
+
+	// Delete removes a game permanently. It happens only when the player asks,
+	// never as a consequence of a sync.
+	Delete(ctx context.Context, id library.GameID) error
+
+	// SetSetting writes one setting.
+	SetSetting(ctx context.Context, key, value string) error
+
+	// SaveConnection records or replaces a provider connection.
+	//
+	// accountRef is an identifier and never a secret — the Steam ID, a GOG
+	// username. Secrets go to the Vault, which is a different interface in a
+	// different package for exactly this reason: the two destinations cannot
+	// be confused if there is no method here that could take one.
+	SaveConnection(ctx context.Context, p provider.ID, accountRef string, at time.Time) error
+
+	// DeleteConnection forgets a provider connection. It does not touch the
+	// games that provider contributed: disconnecting Steam is not a statement
+	// about what the player owns, and the rows carry the player's own work.
+	DeleteConnection(ctx context.Context, p provider.ID) error
+
+	// Close releases the file.
+	//
+	// It must checkpoint WAL and leave exactly one file behind. "One SQLite
+	// file you can back up, move, or delete" is a published promise, and -wal
+	// and -shm companions surviving a clean exit would make it two.
+	Close() error
+}

--- a/internal/store/storetest/fake.go
+++ b/internal/store/storetest/fake.go
@@ -1,0 +1,516 @@
+// Package storetest holds an in-memory store, so every screen and every
+// command can be tested with no database and no network.
+//
+// It is a test double, not a reference implementation: it has no SQL, no
+// migrations, no WAL and no file. What it does share with a real store is the
+// contract, and it enforces the parts of that contract that are rules rather
+// than mechanics — the tombstone guard, the sync-never-writes-a-manual-status
+// invariant, and the requirement that the summary counts sum.
+//
+// A fake that were merely permissive would let a real store violate those and
+// still pass every test written against the fake, which is how a contract
+// quietly becomes a suggestion.
+package storetest
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/aged"
+	"github.com/JustCode-CruzAlex/Zerado/internal/fault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/library"
+	"github.com/JustCode-CruzAlex/Zerado/internal/metadata"
+	"github.com/JustCode-CruzAlex/Zerado/internal/pricing"
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/status"
+	"github.com/JustCode-CruzAlex/Zerado/internal/store"
+)
+
+// Fake is an in-memory store.
+//
+// Playtime capability is supplied per provider through [Fake.Playtime] rather
+// than read from a registry, because a store must not depend on the provider
+// seam to answer a query — and because a test wants to flip that capability
+// without building a provider.
+type Fake struct {
+	mu sync.Mutex
+
+	games    map[library.GameID]library.Game
+	nextID   library.GameID
+	runs     map[store.RunID]store.SyncRun
+	nextRun  store.RunID
+	conns    map[provider.ID]store.Connection
+	settings map[string]string
+	meta     map[library.GameID]aged.Value[metadata.Metadata]
+	quotes   map[quoteKey]aged.Value[pricing.Quote]
+
+	// Playtime reports whether a provider can report playtime, which the
+	// effective-status derivation needs. Absent means false, which is the
+	// honest default for a source nothing is known about.
+	Playtime map[provider.ID]bool
+
+	// Now supplies the clock.
+	Now func() time.Time
+}
+
+type quoteKey struct {
+	id  library.GameID
+	cur pricing.Currency
+}
+
+// New returns an empty Fake with a fixed clock.
+func New() *Fake {
+	base := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	return &Fake{
+		games:    map[library.GameID]library.Game{},
+		runs:     map[store.RunID]store.SyncRun{},
+		conns:    map[provider.ID]store.Connection{},
+		settings: map[string]string{},
+		meta:     map[library.GameID]aged.Value[metadata.Metadata]{},
+		quotes:   map[quoteKey]aged.Value[pricing.Quote]{},
+		Playtime: map[provider.ID]bool{},
+		Now:      func() time.Time { return base },
+	}
+}
+
+func (f *Fake) matches(g library.Game, q library.Query) bool {
+	if g.MergedInto != nil {
+		return false
+	}
+	switch q.Presence {
+	case library.PresentOnly:
+		if g.Absent() {
+			return false
+		}
+	case library.AbsentOnly:
+		if !g.Absent() {
+			return false
+		}
+	}
+	if q.Search != "" && !strings.Contains(fold(g.Title), fold(q.Search)) {
+		return false
+	}
+	if len(q.Sources) > 0 && !containsID(q.Sources, g.Provider) {
+		return false
+	}
+	if len(q.States) > 0 {
+		s := g.Status(f.Playtime[g.Provider])
+		if !containsStatus(q.States, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// fold is the fake's stand-in for the store's own case folding.
+//
+// A real store folds case and diacritics in SQL, with collation that handles
+// the accented titles the library already contains. This is deliberately not
+// that: a fake that reimplemented collation would be a second implementation
+// to keep correct, and the property tests care about is that an empty query
+// filters nothing.
+func fold(s string) string { return strings.ToLower(s) }
+
+func containsID(xs []provider.ID, x provider.ID) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStatus(xs []status.Status, x status.Status) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+// Games returns matching games ordered by sort title.
+func (f *Fake) Games(_ context.Context, q library.Query) ([]library.Game, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var out []library.Game
+	for _, g := range f.games {
+		if f.matches(g, q) {
+			out = append(out, g)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SortTitle != out[j].SortTitle {
+			return out[i].SortTitle < out[j].SortTitle
+		}
+		return out[i].ID < out[j].ID
+	})
+	if q.Offset > 0 {
+		if q.Offset >= len(out) {
+			return nil, nil
+		}
+		out = out[q.Offset:]
+	}
+	if q.Limit > 0 && q.Limit < len(out) {
+		out = out[:q.Limit]
+	}
+	return out, nil
+}
+
+// Game returns one game.
+func (f *Fake) Game(_ context.Context, id library.GameID) (library.Game, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g, ok := f.games[id]
+	if !ok || g.MergedInto != nil {
+		return library.Game{}, fault.New(fault.KindNotFound, "storetest.Game")
+	}
+	return g, nil
+}
+
+// Counts returns the summary for the same set Games would return.
+//
+// Limit and Offset are ignored, because the summary describes the filtered set
+// rather than the visible page — the rule that stops a list view lying about
+// what it is showing.
+func (f *Fake) Counts(_ context.Context, q library.Query) (status.Counts, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var c status.Counts
+	for _, g := range f.games {
+		if f.matches(g, q) {
+			c.Add(g.Status(f.Playtime[g.Provider]))
+		}
+	}
+	return c, nil
+}
+
+// Connections returns every connected provider.
+func (f *Fake) Connections(context.Context) ([]store.Connection, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]store.Connection, 0, len(f.conns))
+	for _, c := range f.conns {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Provider < out[j].Provider })
+	return out, nil
+}
+
+// LastRun returns the most recent run for a provider, or nil when there has
+// never been one.
+func (f *Fake) LastRun(_ context.Context, p provider.ID) (*store.SyncRun, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var best *store.SyncRun
+	for _, r := range f.runs {
+		if r.Provider != p {
+			continue
+		}
+		if best == nil || r.StartedAt.After(best.StartedAt) {
+			cp := r
+			best = &cp
+		}
+	}
+	return best, nil
+}
+
+// Setting reads one setting.
+func (f *Fake) Setting(_ context.Context, key string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.settings[key]
+	return v, ok, nil
+}
+
+// Metadata returns cached enrichment, stamped.
+func (f *Fake) Metadata(_ context.Context, id library.GameID) (aged.Value[metadata.Metadata], bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.meta[id]
+	return v, ok, nil
+}
+
+// Quote returns the last known price, stamped.
+func (f *Fake) Quote(_ context.Context, id library.GameID, cur pricing.Currency) (aged.Value[pricing.Quote], bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.quotes[quoteKey{id, cur}]
+	return v, ok, nil
+}
+
+// SetStatus sets or clears the manual status and stamps the change.
+//
+// A clear is a change: status_changed_at is written for it, because it is
+// something the player did and because Phase 4's last-write-wins needs a
+// timestamp for it to compare.
+func (f *Fake) SetStatus(_ context.Context, id library.GameID, s *status.Status) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g, ok := f.games[id]
+	if !ok {
+		return fault.New(fault.KindNotFound, "storetest.SetStatus")
+	}
+	if s != nil && !s.Valid() {
+		return fault.New(fault.KindMalformed, "storetest.SetStatus")
+	}
+	now := f.Now()
+	g.StatusManual = s
+	g.StatusChangedAt = &now
+	f.games[id] = g
+	return nil
+}
+
+// UpsertBatch writes items and reports what changed.
+//
+// It never touches StatusManual or StatusChangedAt. That omission is the
+// invariant: a sync updates playtime and last-played and nothing else, so a
+// game marked ZERADO stays ZERADO through any number of syncs.
+func (f *Fake) UpsertBatch(_ context.Context, p provider.ID, items []provider.Item) (store.BatchResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var res store.BatchResult
+	for _, it := range items {
+		if existing, id, ok := f.findRef(p, it.ProviderRef); ok {
+			updated := existing
+			updated.Title = it.Title
+			updated.Platform = it.Platform
+			updated.SortTitle = sortTitle(it.Title)
+			updated.PlaytimeMinutes = it.PlaytimeMinutes
+			updated.LastPlayed = it.LastPlayed
+			updated.OwnedSince = it.OwnedSince
+			// A game that came back has its absence cleared, silently.
+			updated.AbsentSince = nil
+			if changed(existing, updated) {
+				res.Changed++
+			} else {
+				res.Unchanged++
+			}
+			f.games[id] = updated
+			continue
+		}
+		f.nextID++
+		f.games[f.nextID] = library.Game{
+			ID:              f.nextID,
+			UID:             library.UID(sortTitle(it.Title) + "|" + strings.ToLower(it.Platform)),
+			Provider:        p,
+			ProviderRef:     it.ProviderRef,
+			Title:           it.Title,
+			Platform:        it.Platform,
+			SortTitle:       sortTitle(it.Title),
+			PlaytimeMinutes: it.PlaytimeMinutes,
+			LastPlayed:      it.LastPlayed,
+			OwnedSince:      it.OwnedSince,
+			AddedAt:         f.Now(),
+		}
+		res.New++
+	}
+	return res, nil
+}
+
+func changed(a, b library.Game) bool {
+	return a.Title != b.Title ||
+		a.Platform != b.Platform ||
+		!eqIntPtr(a.PlaytimeMinutes, b.PlaytimeMinutes) ||
+		!eqTimePtr(a.LastPlayed, b.LastPlayed) ||
+		!eqTimePtr(a.OwnedSince, b.OwnedSince) ||
+		(a.AbsentSince != nil) != (b.AbsentSince != nil)
+}
+
+func eqIntPtr(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func eqTimePtr(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
+}
+
+func sortTitle(s string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.ToLower(s), "the "))
+}
+
+func (f *Fake) findRef(p provider.ID, ref string) (library.Game, library.GameID, bool) {
+	for id, g := range f.games {
+		if g.Provider == p && g.ProviderRef == ref {
+			return g, id, true
+		}
+	}
+	return library.Game{}, 0, false
+}
+
+// AddManual writes a hand-entered item.
+func (f *Fake) AddManual(_ context.Context, p provider.ID, it provider.Item, s *status.Status) (library.GameID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, _, exists := f.findRef(p, it.ProviderRef); exists {
+		return 0, fault.New(fault.KindConflict, "storetest.AddManual")
+	}
+	f.nextID++
+	now := f.Now()
+	g := library.Game{
+		ID:          f.nextID,
+		UID:         library.UID(sortTitle(it.Title) + "|" + strings.ToLower(it.Platform)),
+		Provider:    p,
+		ProviderRef: it.ProviderRef,
+		Title:       it.Title,
+		Platform:    it.Platform,
+		SortTitle:   sortTitle(it.Title),
+		OwnedSince:  it.OwnedSince,
+		AddedAt:     now,
+	}
+	if s != nil {
+		g.StatusManual = s
+		g.StatusChangedAt = &now
+	}
+	f.games[f.nextID] = g
+	return f.nextID, nil
+}
+
+// StartRun opens a run.
+func (f *Fake) StartRun(_ context.Context, p provider.ID, at time.Time) (store.RunID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextRun++
+	f.runs[f.nextRun] = store.SyncRun{ID: f.nextRun, Provider: p, StartedAt: at, Status: store.RunRunning}
+	return f.nextRun, nil
+}
+
+// FinishRun closes a run.
+func (f *Fake) FinishRun(_ context.Context, id store.RunID, r store.RunResult) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	run, ok := f.runs[id]
+	if !ok {
+		return fault.New(fault.KindNotFound, "storetest.FinishRun")
+	}
+	fin := r.FinishedAt
+	run.FinishedAt = &fin
+	run.Status = r.Status
+	run.Seen, run.New, run.Changed, run.Unchanged = r.Seen, r.New, r.Changed, r.Unchanged
+	run.FaultKind = r.FaultKind
+	f.runs[id] = run
+
+	if c, ok := f.conns[run.Provider]; ok {
+		c.LastSyncAt = &fin
+		c.LastSyncStatus = r.Status
+		f.conns[run.Provider] = c
+	}
+	return nil
+}
+
+// ReconcileAbsence tombstones rows a completed run did not return.
+//
+// The guard is the whole reason this method takes a RunID: only a run whose
+// status is ok may tombstone anything, because in a truncated stream "not
+// returned" and "not reached" are indistinguishable. A partial, failed or
+// cancelled run is refused here rather than merely discouraged in a comment.
+func (f *Fake) ReconcileAbsence(_ context.Context, id store.RunID, seen []string) (store.Absence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	run, ok := f.runs[id]
+	if !ok {
+		return store.Absence{}, fault.New(fault.KindNotFound, "storetest.ReconcileAbsence")
+	}
+	if run.FinishedAt == nil || !run.Status.MayTombstone() {
+		return store.Absence{}, fault.New(fault.KindPrecondition, "storetest.ReconcileAbsence",
+			fault.WithMessage("fault.precondition"))
+	}
+
+	present := make(map[string]bool, len(seen))
+	for _, r := range seen {
+		present[r] = true
+	}
+
+	var a store.Absence
+	now := f.Now()
+	for id, g := range f.games {
+		if g.Provider != run.Provider {
+			continue
+		}
+		switch {
+		case present[g.ProviderRef] && g.Absent():
+			g.AbsentSince = nil
+			f.games[id] = g
+			a.Returned++
+		case !present[g.ProviderRef] && !g.Absent():
+			t := now
+			g.AbsentSince = &t
+			f.games[id] = g
+			a.MarkedAbsent++
+		}
+	}
+	return a, nil
+}
+
+// Delete removes a game. It happens only because the player asked.
+func (f *Fake) Delete(_ context.Context, id library.GameID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.games[id]; !ok {
+		return fault.New(fault.KindNotFound, "storetest.Delete")
+	}
+	delete(f.games, id)
+	return nil
+}
+
+// SetSetting writes one setting.
+func (f *Fake) SetSetting(_ context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.settings[key] = value
+	return nil
+}
+
+// SaveConnection records a connection. accountRef is an identifier, never a
+// secret: there is no method here that could accept one.
+func (f *Fake) SaveConnection(_ context.Context, p provider.ID, accountRef string, at time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.conns[p]
+	c.Provider, c.AccountRef, c.ConnectedAt = p, accountRef, at
+	f.conns[p] = c
+	return nil
+}
+
+// DeleteConnection forgets a connection without touching the games it
+// contributed.
+func (f *Fake) DeleteConnection(_ context.Context, p provider.ID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.conns, p)
+	return nil
+}
+
+// Close does nothing; there is no file.
+func (f *Fake) Close() error { return nil }
+
+// PutMetadata and PutQuote seed the Phase 2 and Phase 3 caches, so an offline
+// test can exercise the stale-value screens without a metadata or price
+// provider existing yet.
+func (f *Fake) PutMetadata(id library.GameID, v aged.Value[metadata.Metadata]) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.meta[id] = v
+}
+
+// PutQuote seeds a cached price.
+func (f *Fake) PutQuote(id library.GameID, cur pricing.Currency, v aged.Value[pricing.Quote]) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.quotes[quoteKey{id, cur}] = v
+}
+
+var _ store.Store = (*Fake)(nil)

--- a/internal/store/storetest/fake.go
+++ b/internal/store/storetest/fake.go
@@ -337,8 +337,15 @@ func eqTimePtr(a, b *time.Time) bool {
 	return a.Equal(*b)
 }
 
+// sortTitle is the fake's stand-in for the store's collation key.
+//
+// One ToLower, not two — the outer call in the first version was a no-op over
+// an already-lowered string. A real store folds diacritics and strips articles
+// with collation that handles the accented titles the library already
+// contains; fft-database owns that derivation, and reimplementing it here
+// would be a second version to keep correct.
 func sortTitle(s string) string {
-	return strings.ToLower(strings.TrimPrefix(strings.ToLower(s), "the "))
+	return strings.TrimPrefix(strings.ToLower(s), "the ")
 }
 
 func (f *Fake) findRef(p provider.ID, ref string) (library.Game, library.GameID, bool) {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -1,0 +1,113 @@
+// Package vault is where the player's own keys live, and it is deliberately
+// not the library file.
+//
+// The Steam API key is the player's own key, and library.db is a file the
+// player is explicitly invited to back up, move and delete. A credential
+// inside it would be a credential in every backup, every copy, and every
+// support-ticket attachment.
+//
+// This strengthens the one-file promise rather than violating it: the library
+// file stays purely a library, so sharing it is safe. Settings shows which
+// backing is in use because a security property the player cannot see is a
+// security property they cannot rely on.
+package vault
+
+import (
+	"context"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+)
+
+// Vault stores and retrieves per-provider secrets.
+//
+// It is keyed by (provider, key) rather than by a single string, so that
+// forgetting one provider cannot reach another's secrets and so that
+// [Vault.DeleteProvider] is a complete operation rather than a loop the caller
+// has to get right.
+type Vault interface {
+	// Get returns a stored secret. ok is false when nothing is stored, which
+	// is not an error — a first run has no keys and that is the normal state.
+	Get(ctx context.Context, p provider.ID, key string) (value string, ok bool, err error)
+
+	// Set stores a secret, replacing any previous value.
+	Set(ctx context.Context, p provider.ID, key, value string) error
+
+	// Delete forgets one secret.
+	Delete(ctx context.Context, p provider.ID, key string) error
+
+	// DeleteProvider forgets every secret for a provider.
+	//
+	// It exists because Z-09's disconnect must leave nothing behind, and a
+	// caller looping over the field keys it happens to remember would leave
+	// behind exactly the field somebody added last week.
+	DeleteProvider(ctx context.Context, p provider.ID) error
+
+	// Backing reports where secrets are actually being kept.
+	//
+	// Never a guess and never aspirational: it reports what this process
+	// resolved at start-up, so a keychain that was unavailable reads as the
+	// file backing rather than as the keychain it wanted to be.
+	Backing() Backing
+}
+
+// Backing is where the vault is storing secrets, in enough detail for Z-09 to
+// name it.
+//
+// The spine's shape returned a string, "keychain" or "file". Z-09 needs more
+// than that: its copy is "In the macOS Keychain", "In the GNOME keyring", "In
+// Windows Credential Manager" — whichever the vault reports — and a two-valued
+// string cannot distinguish those three. A struct with a kind and a platform
+// name can, without the screen switching on runtime.GOOS, which would put a
+// platform assumption in a renderer.
+type Backing struct {
+	// Kind is which of the two mechanisms is in use.
+	Kind BackingKind
+
+	// NameKey names the catalogue entry that renders the specific backing —
+	// the macOS Keychain, the GNOME keyring, Windows Credential Manager, or
+	// the credentials file with its mode.
+	//
+	// The vault supplies the key because the vault is the only thing that
+	// knows which service it actually opened. A screen that derived this from
+	// the operating system would be right by coincidence and wrong inside a
+	// container.
+	NameKey string
+
+	// Path is the file's location when Kind is BackingFile, and empty
+	// otherwise. Shown in Settings so the player can find, inspect and delete
+	// it.
+	Path string
+}
+
+// BackingKind is the storage mechanism.
+type BackingKind uint8
+
+const (
+	// BackingUnknown is the zero value, before resolution. A vault that
+	// reports it has not started up correctly.
+	BackingUnknown BackingKind = iota
+
+	// BackingKeychain is the operating system's own secret store: macOS
+	// Keychain, Secret Service, Windows Credential Manager. Preferred.
+	BackingKeychain
+
+	// BackingFile is credentials.json beside the library, mode 0600.
+	//
+	// It is a fallback and not a failure. Headless Linux and containers are a
+	// real part of a terminal-first audience, and a keychain-only design would
+	// simply not run there — so Settings states the backing plainly rather
+	// than the product pretending both are the same.
+	BackingFile
+)
+
+// String returns the stable machine name, used in the CLI's JSON output.
+func (k BackingKind) String() string {
+	switch k {
+	case BackingKeychain:
+		return "keychain"
+	case BackingFile:
+		return "file"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,0 +1,70 @@
+package vault_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/vault"
+	"github.com/JustCode-CruzAlex/Zerado/internal/vault/vaulttest"
+)
+
+// TestDisconnectLeavesNothingBehind. DeleteProvider exists because a caller
+// looping over the field keys it happens to remember would leave behind
+// exactly the field somebody added last week.
+func TestDisconnectLeavesNothingBehind(t *testing.T) {
+	v := vaulttest.New()
+	ctx := context.Background()
+	_ = v.Set(ctx, "steam", "api_key", "SECRET")
+	_ = v.Set(ctx, "steam", "refresh_token", "ALSO-SECRET")
+	_ = v.Set(ctx, "gog", "api_key", "OTHER")
+
+	if err := v.DeleteProvider(ctx, "steam"); err != nil {
+		t.Fatalf("DeleteProvider: %v", err)
+	}
+	if _, ok, _ := v.Get(ctx, "steam", "refresh_token"); ok {
+		t.Fatal("a secret survived the disconnect")
+	}
+	if _, ok, _ := v.Get(ctx, "gog", "api_key"); !ok {
+		t.Fatal("forgetting one provider reached another's secrets")
+	}
+	if v.Len() != 1 {
+		t.Fatalf("%d secrets remain, want 1", v.Len())
+	}
+}
+
+// TestBackingIsNamedSpecificallyEnoughForSettings. The spine's shape returned
+// "keychain" or "file"; Z-09's copy names the macOS Keychain, the GNOME
+// keyring and Windows Credential Manager, which a two-valued string cannot
+// distinguish — and which a screen must not derive from runtime.GOOS, because
+// that is right by coincidence and wrong inside a container.
+func TestBackingIsNamedSpecificallyEnoughForSettings(t *testing.T) {
+	v := vaulttest.New()
+	b := v.Backing()
+	if b.Kind == vault.BackingUnknown {
+		t.Fatal("the vault reports an unresolved backing; a security property the player cannot see is one they cannot rely on")
+	}
+	if b.NameKey == "" {
+		t.Fatal("Settings has no catalogue key for the specific backing in use")
+	}
+	if b.Kind == vault.BackingFile && b.Path == "" {
+		t.Fatal("the file backing does not say where the file is; the player cannot find, inspect or delete it")
+	}
+
+	v.Back = vault.Backing{Kind: vault.BackingKeychain, NameKey: "settings.vault.keychain.macos"}
+	if got := v.Backing().Kind.String(); got != "keychain" {
+		t.Fatalf("BackingKind name = %q", got)
+	}
+}
+
+// TestMissingIsNotAnError: a first run has no keys and that is the normal
+// state, not a failure to report.
+func TestMissingIsNotAnError(t *testing.T) {
+	v := vaulttest.New()
+	got, ok, err := v.Get(context.Background(), "steam", "api_key")
+	if err != nil {
+		t.Fatalf("Get on an empty vault errored: %v", err)
+	}
+	if ok || got != "" {
+		t.Fatalf("Get = %q, %v", got, ok)
+	}
+}

--- a/internal/vault/vaulttest/fake.go
+++ b/internal/vault/vaulttest/fake.go
@@ -1,0 +1,90 @@
+// Package vaulttest holds an in-memory vault, so a test never touches a real
+// keychain and never writes a file.
+package vaulttest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/JustCode-CruzAlex/Zerado/internal/provider"
+	"github.com/JustCode-CruzAlex/Zerado/internal/vault"
+)
+
+// Fake stores secrets in a map.
+//
+// Backing is settable so a test can exercise both of Z-09's honest lines —
+// "In the OS keychain" and "In credentials.json, mode 0600" — without a
+// platform that has one and a platform that does not.
+type Fake struct {
+	mu   sync.Mutex
+	data map[key]string
+
+	// Back is what Backing reports. Defaults to the file backing, which is
+	// the pessimistic one: a test that passes against the fallback passes
+	// against the keychain.
+	Back vault.Backing
+}
+
+type key struct {
+	p provider.ID
+	k string
+}
+
+// New returns an empty Fake reporting the file backing.
+func New() *Fake {
+	return &Fake{
+		data: map[key]string{},
+		Back: vault.Backing{Kind: vault.BackingFile, NameKey: "settings.vault.file", Path: "/tmp/credentials.json"},
+	}
+}
+
+// Get returns a stored secret.
+func (f *Fake) Get(_ context.Context, p provider.ID, k string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.data[key{p, k}]
+	return v, ok, nil
+}
+
+// Set stores a secret.
+func (f *Fake) Set(_ context.Context, p provider.ID, k, v string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key{p, k}] = v
+	return nil
+}
+
+// Delete forgets one secret.
+func (f *Fake) Delete(_ context.Context, p provider.ID, k string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, key{p, k})
+	return nil
+}
+
+// DeleteProvider forgets every secret for a provider, which is what a
+// disconnect needs and what a caller looping over remembered field names
+// would get wrong.
+func (f *Fake) DeleteProvider(_ context.Context, p provider.ID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k := range f.data {
+		if k.p == p {
+			delete(f.data, k)
+		}
+	}
+	return nil
+}
+
+// Backing reports where secrets are kept.
+func (f *Fake) Backing() vault.Backing { return f.Back }
+
+// Len reports how many secrets are held, for a test asserting that a
+// disconnect left nothing behind.
+func (f *Fake) Len() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.data)
+}
+
+var _ vault.Vault = (*Fake)(nil)


### PR DESCRIPTION
## What this is

Ticket #6 — the exact **shape** of every boundary in Zerado. The spine decided *that* these seams exist; this decides their signatures.

**Contracts and doc comments only.** No provider, store, image or audio implementation is written. What ships is the interfaces, the domain types, the reasoning beside each signature, three `Null` implementations the ADR itself designates as first-class *states*, one hand-entry reference provider, five test fakes, and 104 tests that make the contracts checkable rather than assertable.

- `docs/api/00-index.md` — the dossier, and the ratification gate question answered by demonstration
- 36 Go files, 15 test files, **green under `-race`, with no third-party dependency** (`go.mod` declares no `require`, so there is no `go.sum`)

## Branch base — verified

```
$ git merge-base origin/release/0.0.2 HEAD
396d59dd5152ba97ff79cb597ed5d63a2c5e6155
```

`396d59d` is the head of `origin/release/0.0.2`, later than `978a8e5`. `site/`, `docs/content/` and `docs/brand/` are all present in this tree, so anything verified here was verified against files that exist.

## The gate question, shown rather than asserted

> Can a second store, a second metadata source, and a second media type each be added without changing a signature above the seam?

**A second store.** The provider seam carries two implementations already, and they are as different as the product will ever have to accommodate:

| | `providertest.Fake` | `providertest.Manual` |
|---|---|---|
| What it is | a network store | a person typing |
| Implements | `Provider` + `Syncer` | `Provider` + `Enterer` |
| Credentials | two fields, one secret | **none** |
| Playtime | reported | **unknowable** |
| Provider reference | the store's own id | **a UUID Zerado mints** |

Both produce the same `provider.Item`, travel the same `UpsertBatch` path, and derive correctly from `Capabilities` with no branch on identity anywhere. `TestManualIsNotASyncer` asserts the negative the compiler cannot.

**A second metadata source.** Two implementations run through one interface in `TestTheSeamNamesNoProvider`. The stronger evidence is absence: *IGDB* appears **only in comments** — seven occurrences across three files — and in **no signature, type, field or constant**. The fake is keyed on **title and platform** — the shape a source that has never heard of Steam would have, and therefore the shape a cartridge needs. A fake keyed on an appid would have agreed with a Steam-shaped seam and proved nothing.

**A second media type.** The ratified answer is that there must not be a generic seam — see the finding below.

## The two seams that carried unusual weight

**The provider seam holds a shape that is not a store.** Designed against the cartridge first. Read `providertest.Manual` and note what is absent: no credentials, no pagination, no rate limit, no HTTP client, no `Sync`, no playtime. Each absence is a place a one-interface design would have forced `physical` to lie. `Enterer` is a **capability, not a provider kind** — a future GOG that syncs *and* accepts a hand-added game implements both, and Z-08 gains a source picker rather than a special case.

**The metadata seam stays a hedge.** Affiliate links are dropped, so the product is cleanly non-commercial and IGDB's published test is answered — *as a reading of a published rationale, not a guarantee*. The hedge is unchanged: removing it because one risk receded would be the wrong lesson.

## The error taxonomy

Thirteen kinds, each with a screen treatment, a catalogue key and an exit code. The totality guard was **falsified by the review at `c4c8d95` and repaired at `fbef7f1`**: `Kinds()` is now derived from the same iota range as `Valid()` rather than hand-listed, and four assertions across two packages catch a kind that is listed but has no case in `String`, `Treatment`, `MessageKey` or `ExitCode`. See §2.1 of `docs/api/02-error-taxonomy.md`.

A private Steam profile is `KindEmpty`: a **successful** request, a **well-formed** body, a service that is **up**, a key that **works**. It is structurally distinct from `offline`, `unreachable` and `unauthorized`, with a different treatment (refusal, not banner) and a different exit code.

It is not just a better message. 06 §2.4 forbids tombstoning on any run that is not `ok`, and a caller that cannot tell *"returned nothing"* from *"could not be reached"* cannot honour that. `ReconcileAbsence` therefore takes a **`RunID`, not a `ProviderID`** — the argument type *is* the guard, because passing a provider id would have made the illegal call spellable, and the illegal call deletes the evidence that a player finished a game.

Two rules the type enforces: a fault carries an **`i18n.Key`, never a sentence** (D9), and `Fault.Error()` **deliberately omits its cause** — an `*url.Error` stringifies the whole URL and Steam's URLs carry the API key in the query string, straight into the screen a frustrated player screenshots. Asserted against both the error string and the JSON envelope.

## Offline and staleness, in the signatures

- Every network-derived value is an **`aged.Value[T]`** — there is no way to reach the payload without the age in hand. A `FetchedAt` field can be ignored by a renderer; a wrapper cannot.
- **No store read takes a freshness parameter**, because no read can reach the network. That absence *is* the offline contract: a `ForceFresh` option would be a hole through which a render path could start a request.
- `images.Cover` and `audio.Cue` take **no context and return no error** — a function that cannot block has nothing to cancel.
- **`internal/arch` makes the grep rule executable.** `TestOnlyProvidersMayReachTheNetwork` parses every non-test file and fails if any package outside `internal/provider` imports `net`, `net/http`, `net/url`, `crypto/tls` or `net/rpc`. Verified non-vacuous: a violating import was added temporarily and the test failed by name, then reverted.

## Concurrency

`Sync` returns a `Stream` — items channel, terminal error after close, and a **race-free progress snapshot**. The snapshot is what Z-03 §3.1 needs and a bare channel cannot supply: the denominator, so the screen earns its determinate bar instead of scanning forever. `TotalKnown` is separate from `Total` because zero is a real total (it is the private-profile case). `LastAt` is supplied and "stalled" is not — whether a pause is alarming is a screen's judgement about a player's patience, not a provider's judgement about a socket.

`TestProgressIsReadableWhileTheSyncRuns` reads it from one goroutine while the producer writes, and the suite passes under `-race`.

## Every seam is fakeable with no network

| Seam | Offline double |
|---|---|
| Store provider | `providertest.Fake` · `providertest.Manual` |
| Metadata | `metadata.Null` · `metadatatest.Fake` |
| Price | `pricingtest.Fake` |
| Repository | `storetest.Fake` (in-memory, and it **enforces** the tombstone guard and the manual-status invariant) |
| Credentials | `vaulttest.Fake` |
| Images · Audio | `images.Null` · `audio.Null` · `audiotest.Recorder` |
| Error classifier | a **pure function** over a `Transport` verdict — so `fault` imports no networking and every branch is reachable in a test |

## FINDING — the ticket and the ratified ADR disagree on media polymorphism

Ticket item 9 asks for *"the seams that must be generic so books plug in"*. **ADR-0001 D5 pruned that**, and 06 §7 lists a media-type abstraction as explicitly **not a seam**: *"an interface parameterised on a type that has one value is machinery without a purpose."*

**Ratified canon wins.** `library.Game` has no type parameter and no media-type field. What answers the ticket's *intent* is that the affordance lives in the schema and costs nothing above it — the entity is `item` with `item_type` CHECKed to `'game'`, so a second type is one CHECK constraint and **zero interface changes**.

Surfaced rather than silently resolved, per the brief. Full note: `docs/api/06-divergences.md` §1.

## Other divergences, each with its reason (`docs/api/06-divergences.md`)

The seven load-bearing decisions from 13-handoffs §2 are **unchanged** and each is mapped to where it now lives. Spelling changes: the age moves into `aged.Value[T]`; `Sync` returns a `Stream`; `Enterer` is new; `Vault.Backing()` returns a struct (Z-09 names three keychains, which a two-valued string cannot do without a screen switching on `runtime.GOOS` — right by coincidence, wrong in a container); `Store` gains `StartRun`/`FinishRun` so a *killed* sync is distinguishable from a *cancelled* one.

**Four screen specs carry a stale field name**, at five sites — `Z-04:1027`, `Z-05:399`, `Z-06:366`, `Z-08:75,375` — writing `Capabilities.Progress`, which is the generic-progress model ADR-0001 D5 withdrew. *(This sentence said "two" until `708cfbf`; the shipped dossier has said four since round 1, and only this line was left un-updated.)* The contract uses `Playtime`. Recorded rather than edited from here — this ticket does not own those specs.

## Assumption about ticket #5, stated rather than blocking

The repository interface is written against the **conceptual** ERD and assumes only its load-bearing claims: `status_manual` nullable, `last_played_at NULL` = *not reported*, `absent_since` nullable, the cross-device identity **indexed and not unique**, `(provider_id, provider_ref)` unique, `effective_status` derived and never stored, `sync_run.status ∈ ok · partial · failed · cancelled`.

Column types, indexes and migration sequence are `fft-database`'s and change **nothing** here. One naming inconsistency flagged: the ERD says `item_uid`, 06 §6.2 says `game_uid`; the Go type is `library.UID` and nothing above the store sees the column name.

## One item deferred, with its reason

**Which audio library keeps the default build pure Go** (13-handoffs §4, assigned here) is **not answered**, because the handoff itself requires *"a real per-platform check of cgo dependency, not an assumption"* — a verification against six targets, not a signature decision. It **blocks nothing**: `audio.Null` is the default build and the choice changes no signature in `audio.Audio`, which is the test of whether the build-tag seam is right. `docs/api/07-open-questions.md` §1.

## Withdrawn scope, recorded

A shared **filterable-table component contract** was added by relay on 2026-08-25 and **withdrawn by a later relay the same day** (ticket #8 closed). Nothing of it remains in this branch. Noted in `docs/api/07-open-questions.md` §8 so a reader who finds the earlier instruction knows it was dropped deliberately.

Both relays carried **no ratification authority**; they are recorded as relayed direction so the founder confirms rather than inherits.

## CI

Zero gating checks on this PR is **by design** — Release Discipline puts CI on `main` only, and this bases on `release/0.0.2`. A `go` workflow is added with the same `branches: [main]` trigger as `guardrails.yml`, so it gates when the release line merges. Run locally, from this tree:

```
gofmt -l ./internal        # clean
go vet ./internal/...      # clean
go test -race ./internal/... # 14 packages ok
```

## Self PRE-CHECK

- [x] Rule #18 — feature branch, based on `origin/release/0.0.2` (`merge-base` = `396d59d`)
- [x] Rule #33 — no AI attribution
- [x] Rule #3 / EF-19 — 15 test files ship with the contracts; 104 tests, `-race` green
- [x] `gofmt`, `go vet` clean; empty `go.sum`; no third-party dependency
- [x] Banned community-source name: zero occurrences in every added file
- [x] No `.bak`/`.orig`/backup files tracked; no build output tracked
- [x] Every seam exercised with no network



---

## Remediation — round 1 (`fbef7f1`)

`NOT-GOLDEN` at `c4c8d95`. **MAJOR-1 and all three minors are fixed, plus the four non-blocking suggestions.** The reviewer's two correct corrections to this PR body — the IGDB tally and "empty `go.sum`" — are applied above.

**MAJOR-1 was right, and it refuted two comments in the source, not just this body.** `Kinds()` is now **derived from the same iota range as `Valid()`**, which removes the second source of truth rather than adding a test to reconcile the two. Four assertions close the other half, since a kind that *is* in the set can still inherit a switch default. Re-running the reviewer's own probe — `KindThrottled` between `KindConflict` and `KindCancelled` — now fails **three assertions across two packages**, by number, each naming the missing case. *(This originally said four. `TestKindsCoversTheWholeRange` cannot fire on a mid-block insert — it checks `Kinds()` against the range `Kinds()` is derived from, so it guards the other probe. Refuted at `fbef7f1` and corrected.)*

**MINOR-1** — `Progress.Batches` is **removed**, not given a setter. The reviewer's suggested fix (a `RecordBatch` on `Stream`) would have been the signature change above the seam this ticket's gate question promises is not needed; the real error was putting a consumer-written field on a provider-owned snapshot. `TestEveryProgressFieldIsActuallyWritten` now fails on any `Progress` field still at its zero value after a real stream.

**MINOR-2** — `Duplicates` is package-level; `Registry.Collisions()` is recorded at construction, because after construction the evidence is gone.

**MINOR-3** — four specs at five sites, enumerated from the grep rather than from recollection.

Suggestions: `Fault.MarshalJSON` drops `Cause`; `isBlank` uses `unicode.IsSpace`; `devicesync` gains a leaf-type allow-list so nesting cannot bypass the depth-1 checks; the dangling doc reference is fixed.

111 tests (was 104), `gofmt`/`vet` clean, green under `-race`.



---

## Remediation — round 2 (`4484d9a`)

**GOLDEN** at `fbef7f1`, with three minors and four suggestions recorded for the next round. All seven are folded in here rather than filed, since the branch is warm and every one is contained.

**MINOR-1 — the redaction was a property of the pointer, not of the type.** `MarshalJSON` had a pointer receiver, so `encoding/json` skipped it for a non-addressable value and fell back to reflection over the exported fields — emitting the whole cause, URL and key. The embedded form the reviewer probed *is* the log-sink case the method's own doc comment names. Now a value receiver, in the method set of both spellings; the test probes pointer, value, embedded and slice, and reverting the receiver fails it by name.

**MINOR-2 — the whitespace fix had landed on one path of two.** `providertest.Manual` still trimmed byte-wise ASCII, so `Compose` would mint an Item with a NBSP-only title while the sibling credential path refused one. That file is designated as the reference implementation the physical provider will be, so it would have propagated into shipped code.

**MINOR-3 — a test that could not fail.** Replaced with `TestEveryImportIsStandardLibraryOrLocal`, which walks every non-test import and fails on any third-party path. Verified by adding `golang.org/x/text` to `internal/library`.

**Suggestions:** all four. Plus — two dangling doc references in two rounds is a pattern, so `TestEveryDocReferenceResolves` now checks both citation styles the comments use, full path and bare blueprint/screen filename, against the 202 files under `docs/`. 47 references checked; both forms verified to fail on a rename.

**Refuted claim corrected:** the probe fires three assertions, not four.

112 tests, `gofmt`/`vet` clean, green under `-race`.



---

## Remediation — round 3 (`708cfbf`)

**GOLDEN** at `4484d9a` (3 MINOR, 3 SUGGESTION, all non-blocking). Two things in this round.

### The merge blocker: `go.mod` pinned a language version

`go 1.24` is a **language** version. Go cannot resolve a toolchain from it — `GOTOOLCHAIN=go1.24 go env GOROOT` reports *"go1.24 is a language version but not a toolchain version"* — so anything that resolves the pin before doing its job stops there. The review vehicle does exactly that and failed closed twice **without reaching a line of code**. That is upstream of every test in this module and invisible to all of them.

Now **`go 1.27.0`**: the toolchain this project is developed and reviewed on, so it resolves locally with no download per review or per build. A contributor on an older Go switches automatically — that is what the toolchain directive has been for since 1.21 — so the raised floor costs a transparent download rather than a build failure. Sprint 0 #10's acceptance criteria already required a pinned toolchain version.

Two things stop it recurring: `TestTheGoDirectiveIsAResolvableToolchainVersion` fails on a bare `1.X` (verified by restoring `go 1.24` and watching it fail), and the CI workflow now reads `go-version-file: go.mod` instead of repeating the number.

### The three minors, folded in

**MINOR-1** — `Empty()` and `Facets()` disagreed about `Presence: Either`, so the contract's own idiom indexed an empty slice. The repair is the **invariant, not the case**: `TestEmptyAndFacetsAgree` walks the whole cross-product and asserts that a query reporting itself filtered always names a facet.

**MINOR-2** — the surface could not express `mark --clear`. `Arg.RequiredUnless` plus `Verb.MissingArgs`, and `TestTheSurfaceCanExpressEveryDocumentedInvocation` runs the documented invocations against the declared arities. `TestVerbSurfaceIsStable` pinned only names, which is why the contradiction survived two rounds.

**MINOR-3** — `Classify` returned `*Fault`, so `return fault.Classify(o)` from an error-returning function handed back a typed nil on **success** and `KindOf` reported `KindInternal`: a successful sync rendering Z-11. Both classifiers now return `error`.

All three suggestions taken. 118 tests, `gofmt`/`vet` clean, green under `-race`.
