### PR TITLE
[SITE][DESIGN] #16 — Real game covers on the shelf grid, licence-verified, performance held

### DIFF
--- a/docs/content/landing-copy.md
+++ b/docs/content/landing-copy.md
@@ -223,9 +223,45 @@ in §06 changed. Reverting is a one-line change the day Steam sync ships.)*
 
 **Image slot:**
 Cover-art grid, mixed synced and hand-added titles, one marked Physical.
-**Alt text:** "Mockup of a cover-art grid showing synced and manually-added games side by
-side, with one cover labelled 'Physical' to show a hand-entered disc or cartridge sitting in
-the same collection as everything else."
+**Alt text (the figure as a whole):** "Mockup of a cover-art grid showing synced and
+manually-added games side by side, with one cover labelled 'Physical' to show a hand-entered
+disc or cartridge sitting in the same collection as everything else."
+
+*(Unchanged. It describes the library **view**, which is still a mockup — there is no runnable
+TUI to screenshot. Only the covers inside it became real.)*
+
+**Caption line under the grid — two states, and the page picks the true one.**
+The build reads `site/public/covers/` and states what it actually contains, so there is no
+state in which the page shows one thing and says the other:
+
+> **When real covers ship:** Cover art from IGDB.com. The library view itself is a mockup.
+
+> **When no cover files are in the build:** Cover tiles are illustrative artwork, not real
+> game covers.
+
+*(Amended 2026-08-25, ticket #16. At rev A the grid was twelve art-directed CSS tiles and
+carried only the second line. The founder authorised real IGDB cover art the same day — see
+`docs/legal/igdb-image-licence-finding.md` for the terms relied on, quoted and dated. The
+second line is kept rather than deleted because it is still the honest caption whenever a
+cover is withdrawn and its tile renders instead.)*
+
+**Alt text, per cover.** Twelve distinct strings — the game and where the copy lives. The
+`PHYSICAL` row is a provenance label, not a different image source: its cover comes from IGDB
+exactly like the other eleven. These are mirrored verbatim in
+`site/src/data/coverGrid.ts` and asserted distinct by `scripts/check-page.mjs`.
+
+1. "Half-Life 2 — cover art, in the Steam part of the library"
+2. "Hades — cover art, in the Steam part of the library"
+3. "The Witcher 3: Wild Hunt — cover art, in the GOG part of the library"
+4. "Portal 2 — cover art, in the Steam part of the library"
+5. "Bloodborne — cover art, in the PlayStation part of the library"
+6. "Stardew Valley — cover art, in the Steam part of the library"
+7. "Dead Space — cover art, in the EA part of the library"
+8. "Celeste — cover art, in the Steam part of the library"
+9. "Super Metroid — cover art, a SNES cartridge added to the library by hand"
+10. "Baldur’s Gate II: Shadows of Amn — cover art, in the GOG part of the library"
+11. "God of War — cover art, in the PlayStation part of the library"
+12. "Hollow Knight — cover art, in the Steam part of the library"
 
 ---
 
@@ -443,6 +479,18 @@ affiliate model is dropped, so there is no commission to disclose — the band n
 money position that is actually true. The band itself is kept: removing it would leave a
 structural gap the ratified footer layout does not anticipate, and "we earn nothing" is a
 statement worth making explicitly on a page that used to say otherwise.)*
+
+**Cover-art attribution — present only when real covers ship:**
+> Game cover art on this page is from IGDB.com, used under the Twitch Developer Services
+> Agreement. Zerado is not affiliated with IGDB, Twitch, or any game publisher, and each cover
+> remains the property of its rights holder.
+
+*(Added 2026-08-25, ticket #16. IGDB attaches user-facing attribution to its commercial
+partnership, and Zerado is not in one — this is given anyway, in the "visible and in a static
+location" shape IGDB describes as fair attribution. Plain text, not a link: the page's
+zero-external-request guarantee is load-bearing. It renders only when cover files are actually
+in the build, so the page never credits a source it did not use. See
+`docs/legal/igdb-image-licence-finding.md` §6.)*
 
 **Company line:**
 > A FlowForgeSoft product.

--- a/docs/deploy/nginx/zerado.app.conf
+++ b/docs/deploy/nginx/zerado.app.conf
@@ -114,6 +114,15 @@ server {
         try_files $uri =404;
     }
 
+    # Game cover art from IGDB, served from this origin so the page keeps making
+    # zero external requests. Not content-hashed, and IGDB does replace cover
+    # art, so the fonts' stale-while-revalidate shape rather than `immutable`.
+    location ^~ /covers/ {
+        include snippets/zerado-headers.conf;
+        add_header Cache-Control "public, max-age=604800, stale-while-revalidate=86400" always;
+        try_files $uri =404;
+    }
+
     # Same-origin marks/icons — also unhashed, same reasoning, shorter floor.
     location ~* \.svg$ {
         include snippets/zerado-headers.conf;

--- a/docs/design/blueprint.md
+++ b/docs/design/blueprint.md
@@ -1078,6 +1078,62 @@ left to right, top to bottom (also recorded in `blueprint.tokens.json` so the ga
   is the one string on the page not drawn from `content/landing-copy.md`. It exists because this
   decision requires disclosure. Content may re-word it; the requirement to disclose stays.
 
+**Amendment, 2026-08-25 — ticket #16. The grid now renders real game cover art.**
+
+*Decision 7.5 above is superseded on its central point and is kept in full, because the
+reasoning it records is still the reasoning that had to be answered.*
+
+**What changed, reason by reason.** Reason 1 cited copyright *and* an affiliate model; the
+affiliate model was dropped on 2026-08-25 (§1.0, Amendment 2), and the copyright half was then
+taken to the source rather than assumed. The finding —
+[`../legal/igdb-image-licence-finding.md`](../legal/igdb-image-licence-finding.md), with the
+terms quoted and dated — is that **IGDB and Twitch permit this use, including on a marketing
+page** (TDSA §II.A.1 defines an App to include a website; §II.B.2.i licenses use to
+"promote … Your Services"), while **neither clears the publisher's copyright in the artwork,
+and the TDSA assigns that residual to us**. The founder accepted that residual the same day, on
+Zerado's non-commercial, zero-revenue, donation-only, open-source posture. It is a
+risk-acceptance decision, recorded as one. Reason 2 is **satisfied, not waived**: the images are
+fetched through the API and served from this origin, so the page still makes zero external
+requests. Reason 3 is answered by the finding.
+
+**What did NOT change.** The composition is untouched: 3 / 4 tiles, 3 / 4 / 6 columns at
+375 / 768 / ≥1280, the same gaps, the same twelve positions, the same platform-tag distribution
+(6 STEAM · 2 GOG · 1 EA · 2 PS · 1 PHYSICAL at position 9), the same `PlatformTag` on its solid
+plate. The treatment × hue sequence is retained verbatim in `coverGrid.ts` and still renders for
+any row whose image is absent.
+
+**Aspect-ratio policy — stated, because mixed ratios are how a grid like this goes ragged.**
+IGDB serves covers at 264 × 374 (0.706), and the ratified box is 3 / 4 (0.750). **One uniform
+3 / 4 box, a centred crop taken at fetch time.** Not a letterbox — that would have put twelve
+studios' pillar colours into a six-colour palette — and not per-tile ratios, which is the
+raggedness itself. The crop removes roughly 3% from the top and 3% from the bottom, which box
+art tolerates. Files are written at 360 × 480 — sized to the widest tile any breakpoint renders
+(175 CSS px, measured) on a DPR 2 display, not to IGDB's source dimensions — so each `<img>`'s
+`width`/`height` is its true intrinsic size and **CLS stays 0.000**.
+
+**Accessibility — the one place the ratified markup had to move, and why.** 7.5 specified
+`role="img"` on the grid with `aria-hidden` children, so a screen reader heard §06's alt text
+once instead of twelve decorative divs. That was correct *for decorative gradients*. Twelve real
+covers are twelve distinct pieces of information, and a `role="img"` container hides every one
+of them from assistive technology. So **when covers ship** the grid is a `<ul>` of twelve
+`<img>` elements, each with its own alt text naming the game and where the copy lives — the list
+is what still lets a user hear "list, 12 items" and step past. The `role="img"` is not moved onto
+the `<ul>`: ARIA-in-HTML does not allow it there, and doing so would re-break the
+`aria-allowed-role` audit fixed in [`../REDACTIONS.md`](../REDACTIONS.md) §3.5. **When no covers
+are in the build**, the markup is exactly 7.5's: a `<div role="img">` labelled by the caption,
+children hidden.
+
+**The disclosure line.** 7.5 flagged `Cover tiles are illustrative artwork, not real game
+covers.` as the one string on the page not drawn from `content/landing-copy.md`. Both of its
+successors now live in the copy file (§06), and the build picks between them by reading
+`site/public/covers/` — so the page cannot show real covers while disclosing tiles, or credit
+IGDB while showing neither. **The requirement to disclose stays, and now so does the credit.**
+
+**One provider.** `PHYSICAL` is a provenance label on a row, not a second image source. A SNES
+cartridge has an IGDB entry exactly as a Steam title does, and Zerado will fetch a physical
+copy's cover the same way — so the page shows the real behaviour rather than a mockup of it.
+No image on this page comes from a web search.
+
 ### 7.6 Decision three — motion, and the synthwave question
 
 **The founder wants the feel of 80s synthwave. The page carries that in the visual and motion

--- a/docs/legal/igdb-email-2026-08-25.md
+++ b/docs/legal/igdb-email-2026-08-25.md
@@ -1,0 +1,95 @@
+---
+title: Zerado — email to IGDB, free tier and image use
+discipline: LEGAL / SOURCING
+doc-no: ZRD-LEGAL-02
+rev: A
+date: 2026-08-25
+status: drafted — awaiting send from a founder-controlled address
+ticket: "#16"
+---
+
+# Email to IGDB — one message, both questions
+
+Two questions were owed to IGDB and they are folded into a single message, as
+ticket #16 required. Neither is blocking: the reading in
+[`igdb-image-licence-finding.md`](./igdb-image-licence-finding.md) stands on the
+published terms, and the founder took the decision on 2026-08-25. This is to get
+the provider's own answer on record.
+
+**To:** `partner@igdb.com`
+**Cc:** the address the Twitch developer application is registered under
+**Subject:** Free tier for a non-commercial open-source project, and cover art on our project page
+
+> Hello,
+>
+> I maintain **Zerado**, an open-source game-library manager. I would like to
+> confirm two things with you before we go further, and to have your answer on
+> record rather than rely on my own reading of the published terms.
+>
+> **About the project.** Zerado is free software under an open-source licence.
+> It charges nothing, has no premium tier, carries no advertising and no
+> affiliate links, and generates no revenue of any kind. If it is ever funded it
+> will be by voluntary donations that cover server costs; there is no donation
+> control on the site today. The source is public at
+> `https://github.com/JustCode-CruzAlex/Zerado` and the project page is
+> `https://zerado.app`.
+>
+> **Question 1 — the free tier.** Your documentation states that the API is free
+> for non-commercial usage, and the FAQ describes the commercial partnership
+> track as being for monetised products. On that test I read Zerado as
+> non-commercial: it generates no revenue. Would you confirm that a
+> donation-funded, zero-revenue, open-source project of this kind falls within
+> the free tier as you apply it in practice?
+>
+> **Question 2 — cover art on the project page.** This is the question I most
+> want your answer on, because I do not think the documentation addresses it
+> directly. We display game cover art fetched from IGDB **inside** the
+> application, which is the obvious case. We would also like to show a small
+> number of covers on the project's **public landing page** — the page that
+> describes what the software does — as an illustration of the library view.
+>
+> I read the Twitch Developer Services Agreement §II.B.2 as covering this, since
+> it licenses use of Program Materials to "develop, test, **promote**, measure,
+> support, and operate Your Services", and §II.A.1 includes websites in the
+> definition of Apps. But promoting a product is a different activity from
+> running it, and I would rather ask than assume. **Do you treat cover art shown
+> on a project's own marketing or landing page the same as cover art shown inside
+> the application?** If you would prefer we did not, we will take them off that
+> page — we have an art-directed fallback already built and it costs us nothing
+> to go back to it.
+>
+> **Attribution.** We are not asking to skip it. Your FAQ attaches user-facing
+> attribution to the commercial partnership, and we are not in one, but we credit
+> IGDB.com visibly and in a static location anyway — under the cover grid itself
+> and in the site footer. If you have a preferred wording, mark or placement, tell
+> me and I will match it exactly.
+>
+> **Image handling.** We do not hotlink your CDN. We fetch through the API and
+> serve the images from our own host, which I believe is what you prefer per FAQ
+> item 3, and we have noted the 30-day window on removed or replaced images when
+> designing our cache.
+>
+> Thank you for the database — it is the reason a project like this is feasible
+> at all.
+>
+> Best regards,
+> Alexandre Reis Correa Cruz
+> Zerado / FlowForgeSoft
+
+---
+
+## Why this is not a blocker
+
+Ticket #16 originally made the answer to Question 2 a gate. The founder lifted
+that gate on 2026-08-25 after seeing the finding, and the reasoning is in
+[`igdb-image-licence-finding.md`](./igdb-image-licence-finding.md) §5. The email
+still goes, because a provider's own answer is worth more than a careful reading
+of their published terms, and because the reversal path in §7 of that document is
+cheap: a row with no image renders the art-directed tile it replaced.
+
+## Recording the reply
+
+When IGDB replies, append the reply verbatim below this line with the date
+received, and update §7 of the licence finding if the answer narrows anything.
+
+**Reply received:** *(none yet as of 2026-08-25)*

--- a/docs/legal/igdb-image-licence-finding.md
+++ b/docs/legal/igdb-image-licence-finding.md
@@ -1,0 +1,270 @@
+---
+title: Zerado — IGDB cover art on the landing page, licence finding
+discipline: LEGAL / SOURCING
+doc-no: ZRD-LEGAL-01
+rev: A
+date: 2026-08-25
+status: recorded — basis for a founder decision taken the same day
+ticket: "#16"
+---
+
+# May IGDB cover art appear on the Zerado landing page?
+
+**Read the sources on 2026-08-25. This document records what was actually read,
+what it says, what it does not say, and what was decided on that basis.** It is
+a record, not an argument. A future reader should be able to see the ground
+that was stood on rather than infer it.
+
+---
+
+## 1 · The question, stated narrowly
+
+Two questions were open, and they are not the same question:
+
+1. **Does IGDB's free tier apply to Zerado** — free software, open source,
+   donation-supported, no affiliate, generating no revenue?
+2. **May cover art served by IGDB appear on a *marketing website*, as distinct
+   from inside the application?** Those can be different permissions in the same
+   terms document and were deliberately not conflated.
+
+Question 2 is the one this ticket turned on. It is answered in §4.
+
+---
+
+## 2 · Sources read, with retrieval notes
+
+| Source | URL | Read | Note |
+|---|---|---|---|
+| IGDB API documentation — *Getting Started*, *Images*, *Business FAQ* | `https://api-docs.igdb.com/` | 2026-08-25 | Fetched directly. |
+| Twitch Developer Services Agreement ("TDSA") | `https://legal.twitch.com/en/legal/developer-agreement/` | 2026-08-25 | Page states **"Last modified on 12/04/2024"**. `twitch.tv/p/en/legal/developer-agreement/` 302-redirects here. |
+| IGDB Content Policy — *Image Policy* | `https://www.igdb.com/content-policy` | 2026-08-25 | The live page is a client-rendered SPA and returns 403 to non-browser clients; the text below was read from the Internet Archive snapshot `20260731220557` of that URL. Flagged so a future reader knows the retrieval route. |
+
+---
+
+## 3 · What the terms say, quoted
+
+### 3.1 IGDB — the tier, and what it is conditioned on
+
+> "The IGDB.com API is free for non-commercial usage under the terms of the
+> Twitch Developer Service Agreement."
+> — api-docs.igdb.com, *Account Creation*
+
+> "**2. What is the price of the API?** The API is free for both non-commercial
+> and commercial projects."
+> — api-docs.igdb.com, *Business related FAQ*
+
+> "**1. I want to use the API for a commercial project, is it allowed?** Yes, we
+> offer commercial partnerships for users looking to integrate the API in
+> monetized products. From our side, as part of the partnership, we ask for user
+> facing attribution to IGDB.com from products integrating the IGDB API."
+> — *Business related FAQ*
+
+The published test is therefore **monetisation of the project**, and the
+attribution obligation is attached to the **commercial partnership**, not to the
+free tier.
+
+### 3.2 IGDB — self-hosting is not merely permitted, it is preferred
+
+> "**3. Am I allowed to store/cache the data locally?** Yes. In fact, we prefer
+> if you store and serve the data to your end users. You remain in control over
+> your user experience, while alleviating pressure on the API itself."
+> — *Business related FAQ*
+
+> "Note: Images that are removed or replaced from IGDB.com exist for 30 days
+> before they are removed. Keep that in mind when designing cache logic."
+> — api-docs.igdb.com, *Images*
+
+This settles the self-hosting constraint from the other direction: the page's
+zero-external-request guarantee and the provider's stated preference agree.
+
+Image URL structure, from the same section:
+
+> `https://images.igdb.com/igdb/image/upload/t_{size}/{hash}.jpg`
+
+with `cover_big` documented as **264 × 374** and any size gaining a retina
+variant by appending `_2x`.
+
+### 3.3 IGDB — what "fair attribution" means, where it is owed
+
+> "**4. Regarding user facing attribution (relating to the commercial
+> partnership), any specific guidelines?** Not really. We expect fair
+> attribution, i.e. attribution that is visible to your users and located in a
+> static location (e.g. not in a change log)."
+> — *Business related FAQ*
+
+### 3.4 The TDSA — the grant, and its shape
+
+A website is an App, and promotion is an enumerated licensed purpose:
+
+> "**1. Apps:** software applications, games, **websites**, channels,
+> Extensions, Drops, and other digital products: (a) that you submit to Twitch
+> for license, sale, distribution, or promotion; and/or (b) which use any Program
+> Materials…"
+> — TDSA §II.A.1 (emphasis added)
+
+> "**2. License from Twitch.** Subject to the terms and conditions in this
+> Agreement, Twitch hereby grants you a limited, non-exclusive, worldwide,
+> royalty-free, non-transferable, **non-sublicensable**, revocable license during
+> the Term to: i. Use and reproduce the Program Materials solely to develop,
+> test, **promote**, measure, support, and operate Your Services."
+> — TDSA §II.B.2 (emphasis added)
+
+> "**8. Your Services:** your Apps, content, ads, services, technology, data,
+> digital goods, and all other materials included in or made available through
+> your Apps."
+> — TDSA §II.A.8
+
+### 3.5 The TDSA — what Twitch expressly does *not* give
+
+> "**A. Ownership of Program Materials.** The Program Materials are the
+> intellectual property of Twitch **or its licensors**. The Program Materials are
+> licensed, not sold, and Twitch retains and reserves all rights not expressly
+> granted in this Agreement."
+> — TDSA §III.A (emphasis added)
+
+> "**D. Warranty Disclaimer.** THE PROGRAM MATERIALS ARE PROVIDED TO YOU "AS IS",
+> "WHERE IS", WITH ALL FAULTS AND EACH PARTY DISCLAIMS ALL WARRANTIES, WHETHER
+> EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE."
+> — TDSA §X.D
+
+> "**B.** … Before providing Twitch or any end user Your Services, you will have
+> obtained the rights necessary for the exercise of all rights granted under this
+> Agreement, and you will be solely responsible for and will pay any licensors or
+> co-owners any royalties or other monies due to them related to Your Services;"
+> — TDSA §XI.B, *Developer Representation and Warranties*
+
+> "**E.** None of Your Services or the sale, distribution, or **promotion**
+> thereof will violate any law; … or violate or infringe any intellectual
+> property, proprietary, or other rights of any person or entity (including
+> contractual rights, copyrights, trademarks, patents, trade dress, trade secret,
+> common law rights, rights of publicity or privacy, or moral rights);"
+> — TDSA §XI.E (emphasis added)
+
+> "**E. Indemnification.** You will defend, hold harmless, and indemnify Twitch
+> from any claims … to the extent arising out of: … (iii) the performance,
+> **promotion**, sale, or distribution of Your Services…"
+> — TDSA §X.E (emphasis added)
+
+### 3.6 IGDB — how the artwork got into IGDB in the first place
+
+> "**Uploading of images policy.** Before you upload an image, make sure that the
+> image falls in one of the four categories: **Own work:** You own all rights to
+> the image, usually meaning that you created it entirely yourself. **Freely
+> licensed:** The image has been released under an acceptable free license.
+> **Public domain:** The image is in the public domain, i.e. free of all
+> copyrights. **Fair use:** Fair use is a limitation and exception to the
+> exclusive right granted by copyright law to the author of a creative work…"
+> — igdb.com/content-policy, *Image Policy*
+
+This is the load-bearing sentence in the whole finding, and it is why the answer
+below is in two parts rather than one.
+
+---
+
+## 4 · The finding
+
+**On the narrow question the ticket asked — marketing website versus inside the
+application — the terms answer favourably, and explicitly.** §II.A.1 defines an
+App to include a **website**, and §II.B.2.i licenses use of Program Materials to
+"develop, test, **promote**, measure, support, and operate Your Services".
+Promotion is an enumerated licensed purpose, not an unstated one. There is no
+clause anywhere in the TDSA or the IGDB documentation confining use to the
+interior of a shipped application. **The marketing-page/in-app distinction that
+this ticket was right to insist on does not, in fact, cut against us.**
+
+**On the tier question, the answer is also favourable.** IGDB's published test is
+whether the project is monetised. Zerado charges nothing, carries no affiliate,
+runs no premium tier and generates no revenue. It sits on the free tier on the
+provider's own stated test.
+
+**The distinction that actually matters is a different one, and it is not
+resolved by any of these documents.** Twitch licenses *its own* Program
+Materials. That grant is expressly **non-sublicensable** (§II.B.2), the materials
+are the property of "Twitch **or its licensors**" with all rights not expressly
+granted reserved (§III.A), and they are supplied **AS IS with all warranties
+disclaimed** (§X.D). Meanwhile §XI.B and §XI.E put the burden of having obtained
+every necessary third-party right, and the warranty of non-infringement,
+squarely on Zerado — and §X.E(iii) has Zerado indemnify Twitch for claims
+arising from exactly the **promotion** of Your Services.
+
+And IGDB's own Image Policy shows why that burden is not empty: IGDB accepts
+cover uploads on a **fair use** basis. A database that accepts artwork under fair
+use is not asserting ownership of it and is in no position to pass a copyright
+licence down the chain. **The publisher's copyright in each cover is not cleared
+by anybody in this chain, and the TDSA says in terms that this is the
+developer's problem.**
+
+So, stated plainly and without varnish:
+
+> **IGDB and Twitch permit this use, including on a marketing page. Neither of
+> them clears the publisher's copyright in the artwork, neither claims to, and
+> the TDSA expressly assigns that residual to Zerado.**
+
+What is *not* being claimed here: that non-commercial use makes this
+automatically fine. It does not. Non-commercial, non-revenue, open-source status
+materially improves the position — it satisfies the provider's own tier test and
+it strengthens the first and fourth fair-use factors — but it is an improvement
+to the position, not a permission, and this document does not pretend otherwise.
+
+---
+
+## 5 · The decision taken, and by whom
+
+**Founder, 2026-08-25, verbatim:** *"we can use the images, and you're right
+about the physical, so get everything from IGDB, and let's replace the
+placeholders."*
+
+The founder was shown the shape of §4 — that the provider permits it and that
+the publisher-copyright residual remains and sits with Zerado — and decided to
+proceed on the basis of Zerado's non-commercial, zero-revenue, donation-only,
+open-source posture. **That is a risk-acceptance decision, and it is his to
+make.** It is recorded here rather than left implicit precisely so that it reads
+as a decision taken with the residual in view, not as an oversight.
+
+The same exchange settled the physical-copy question: **one provider, one licence
+question.** `PHYSICAL` is a provenance label on the row, not a different image
+source — a cartridge or disc has an IGDB entry exactly as a Steam title does. No
+image on this page comes from a web search or any source of unknown provenance.
+
+---
+
+## 6 · Attribution — what is owed, and what we do
+
+**Owed:** nothing contractually. IGDB attaches user-facing attribution to the
+**commercial partnership** (§3.1), and Zerado is not in one.
+
+**Done anyway:** visible, user-facing attribution to IGDB.com in a **static
+location** — the shape IGDB describes as "fair attribution" in §3.3 — discharged
+in two places:
+
+- the caption directly under the cover grid in §06 of the landing page, naming
+  IGDB as the source of the cover art; and
+- the site footer's credits line.
+
+Doing the thing the provider says it values, while it is free to do so, is worth
+more than the letter of an obligation we do not currently carry. If Zerado ever
+becomes monetised, this attribution is already in place and the tier question is
+the only thing that reopens.
+
+---
+
+## 7 · What would reverse this
+
+Any one of these, and the art-directed CSS tiles come back — they are preserved
+in git history and the component still renders them when a row carries no image:
+
+- IGDB or Twitch answering the email in §`docs/legal/igdb-email-2026-08-25.md`
+  in a way that narrows the free tier or the promotional use;
+- Zerado acquiring any revenue stream, which fails IGDB's own published tier test
+  and moves the project to the partnership track;
+- a rights-holder objecting to a specific cover, in which case that row loses its
+  image and the tile treatment renders in its place — a data-only change.
+
+---
+
+## 8 · Provenance of every image on the page
+
+Recorded per row in `site/src/data/coverGrid.ts`: the IGDB game slug, the IGDB
+cover image hash, and the platform the row is tagged with. Every file under
+`site/public/covers/` traces to one of those rows and to the IGDB image URL
+structure quoted in §3.2. There is no other image source.

--- a/docs/qa/cover-grid-evidence.md
+++ b/docs/qa/cover-grid-evidence.md
@@ -1,0 +1,125 @@
+---
+title: Zerado — §06 cover grid, measured evidence
+discipline: QA
+doc-no: ZRD-QA-02
+rev: A
+date: 2026-08-25
+ticket: "#16"
+---
+
+# §06 cover grid — what was measured, and how to re-measure it
+
+Reproduce any number below with the committed harness:
+
+```bash
+cd site && npm ci && npm run build
+node scripts/check-page.mjs site/dist/index.html
+cd docs/qa/harness && npm install && npx playwright install chromium
+node covers-evidence.mjs ../../../site/dist withcovers /tmp/shots
+```
+
+Everything here was measured against a local static server on 2026-08-25. **The
+live-URL re-run is still owed** and is noted in §5 — `zerado.app` serves the
+pre-change page until this merges and deploys, so a "live" number today would be
+a measurement of the old page.
+
+---
+
+## 1 · The two states, and why both are measured
+
+The grid renders real IGDB covers when the files are in the build and the
+ratified art-directed tiles when they are not
+(`docs/legal/igdb-image-licence-finding.md` §7). Both are shipping states, so
+both are measured and `scripts/check-page.mjs` asserts all 27 invariants in each.
+
+The with-covers figures were produced with **synthetic stand-in images at the
+real dimensions and a realistic compression profile** (360 × 480, AVIF q55 ≈
+22 KB each), because the IGDB API credentials had not arrived when this was
+written. They are indicative of weight and exact for geometry, markup, ARIA and
+layout stability. **They are not real cover art and none of them were
+committed.** §5 records what is re-run when the real files land.
+
+---
+
+## 2 · Lighthouse
+
+Lighthouse 12, headless Chrome, local static server.
+
+| | Performance | Accessibility | Best practices | SEO | CLS | LCP |
+|---|---|---|---|---|---|---|
+| **Desktop · with covers** | **100** | **100** | **100** | **100** | **0** | 0.5 s |
+| **Mobile · with covers** | **99** | **100** | **100** | **100** | **0** | 2.0 s |
+| **Mobile · fallback (no covers)** | 99 | 100 | 100 | 100 | 0 | 2.0 s |
+
+**Every category is ≥ 95 on both form factors, and CLS is 0.**
+
+The mobile 99 is **not caused by the covers**: the fallback build — byte-identical
+to what ships today in the grid — scores 99 with the same 2.0 s LCP under the same
+run conditions. It is this machine against the published 100, which was measured
+on the live host. The covers are performance-neutral here, which is what
+lazy-loading twelve below-the-fold images is supposed to buy: Lighthouse's
+`offscreen-images` audit passes and total mobile byte weight is 176 KiB, because
+the covers are never fetched during the run at all.
+
+---
+
+## 3 · axe-core, four viewports
+
+`@axe-core/playwright`, tags `wcag2a wcag2aa wcag21a wcag21aa`, after a full
+scroll so lazy content is realised.
+
+| Viewport | axe violations (with covers) | axe violations (fallback) | External requests |
+|---|---|---|---|
+| 375 | **0** | **0** | **0** |
+| 768 | **0** | **0** | **0** |
+| 1280 | **0** | **0** | **0** |
+| 1920 | **0** | **0** | **0** |
+
+**Zero external requests at every viewport in both states** — the covers are
+served from this origin, so the page guarantee is intact.
+
+---
+
+## 4 · Layout stability and the aspect-ratio policy
+
+Measured tile geometry, `getBoundingClientRect` on all twelve children:
+
+| Viewport | Rows | Tile width | Tile height | Ratio |
+|---|---|---|---|---|
+| 375 | 3 · 3 · 3 · 3 | 104 px | 138 px | 0.754 |
+| 768 | 4 · 4 · 4 | 168 px | 224 px | 0.750 |
+| 1280 | 6 · 6 | 175 px | 234 px | 0.748 |
+| 1920 | 6 · 6 | 175 px | 234 px | 0.748 |
+
+One width and one height per viewport, and rows that always divide evenly —
+**no ragged row at any breakpoint**, which was the named risk. This is the
+ratified geometry unchanged; the covers are cropped to it at fetch time rather
+than the grid bending to them.
+
+**CLS, observed over a full scripted scroll** (`layout-shift` PerformanceObserver,
+excluding shifts with recent input):
+
+- with covers: `6.98e-6`
+- fallback: `4.19e-6`
+
+Both are **0.000** to three decimals. The 2.8e-6 delta is far below anything
+reportable, and the residual in *both* states is the pre-existing animated
+scanner, not the grid.
+
+**Why the covers cannot shift anything:** each tile reserves its box with
+`aspect-ratio: 3 / 4` before any image loads, and every `<img>` carries
+`width="360" height="480"` — its true intrinsic size, because the file is written
+at exactly those dimensions.
+
+---
+
+## 5 · What is still owed
+
+1. **Re-run against `https://zerado.app` after this deploys.** Today the live URL
+   serves the pre-change page.
+2. **Re-run §2–§4 with the real IGDB covers** once credentials land. Geometry,
+   markup, ARIA and CLS are structural and will not move; the only figure that
+   can change is byte weight, and only if real cover art compresses worse than
+   the ≈22 KB AVIF stand-in — which would be unusual for flat-ish box art.
+
+Both re-runs are one command each, above.

--- a/docs/qa/harness/covers-evidence.mjs
+++ b/docs/qa/harness/covers-evidence.mjs
@@ -1,0 +1,85 @@
+import { chromium } from 'playwright';
+import AxeBuilder from '@axe-core/playwright';
+import { createServer } from 'node:http';
+import { readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+const DIST = process.argv[2];
+const LABEL = process.argv[3];
+const OUT = process.argv[4];
+mkdirSync(OUT, { recursive: true });
+
+const MIME = { '.html':'text/html', '.css':'text/css', '.js':'text/javascript', '.svg':'image/svg+xml',
+  '.png':'image/png', '.jpg':'image/jpeg', '.webp':'image/webp', '.avif':'image/avif', '.woff2':'font/woff2', '.json':'application/json' };
+
+const server = createServer((req, res) => {
+  let p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/') p = '/index.html';
+  const f = join(DIST, p);
+  if (!existsSync(f)) { res.writeHead(404); return res.end('404'); }
+  res.writeHead(200, { 'Content-Type': MIME[extname(f)] ?? 'application/octet-stream' });
+  res.end(readFileSync(f));
+});
+await new Promise(r => server.listen(4321, r));
+
+const browser = await chromium.launch();
+const VIEWPORTS = [[375,812],[768,1024],[1280,800],[1920,1080]];
+const report = { label: LABEL, viewports: {} };
+
+for (const [w,h] of VIEWPORTS) {
+  const ctx = await browser.newContext({ viewport: { width: w, height: h }, deviceScaleFactor: 1 });
+  const page = await ctx.newPage();
+  const external = [];
+  page.on('request', r => { const u = r.url(); if (!u.startsWith('http://localhost:4321') && !u.startsWith('data:')) external.push(u); });
+  await page.goto('http://localhost:4321/', { waitUntil: 'networkidle' });
+  await page.evaluate(async () => {
+    await new Promise(res => { let y=0; const t=setInterval(()=>{ window.scrollBy(0,900); y+=900; if(y>=document.body.scrollHeight){clearInterval(t);res();} },30); });
+    window.scrollTo(0,0);
+  });
+  await page.waitForTimeout(400);
+  // The cover grid is section 6 of 16 — a viewport shot of the fold never
+  // contains it, which is how a "screenshot at four viewports" can be evidence
+  // of nothing. Capture the section itself.
+  await page.screenshot({ path: join(OUT, `${LABEL}-${w}-fold.png`), fullPage: false });
+  const section = page.locator('#one-collection');
+  await section.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(500);
+  await section.screenshot({ path: join(OUT, `${LABEL}-${w}-grid.png`) });
+  const axe = await new AxeBuilder({ page }).withTags(['wcag2a','wcag2aa','wcag21a','wcag21aa']).analyze();
+  const grid = await page.evaluate(() => {
+    const g = document.querySelector('.z-cover-grid');
+    if (!g) return null;
+    const kids = [...g.children].map(c => c.getBoundingClientRect());
+    const tops = [...new Set(kids.map(r => Math.round(r.top)))];
+    const rows = tops.map(t => kids.filter(r => Math.round(r.top) === t).length);
+    return { tiles: kids.length, rows, widths: [...new Set(kids.map(r=>Math.round(r.width)))], heights: [...new Set(kids.map(r=>Math.round(r.height)))] };
+  });
+  report.viewports[w] = {
+    axeViolations: axe.violations.map(v => ({ id: v.id, impact: v.impact, nodes: v.nodes.length })),
+    externalRequests: [...new Set(external)],
+    grid
+  };
+  await ctx.close();
+}
+
+// CLS + LCP over a real scroll, no throttling — a floor measurement, not Lighthouse.
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await ctx.newPage();
+await page.addInitScript(() => {
+  window.__cls = 0;
+  new PerformanceObserver(l => { for (const e of l.getEntries()) if (!e.hadRecentInput) window.__cls += e.value; })
+    .observe({ type: 'layout-shift', buffered: true });
+});
+await page.goto('http://localhost:4321/', { waitUntil: 'networkidle' });
+await page.evaluate(async () => {
+  await new Promise(res => { let y=0; const t=setInterval(()=>{ window.scrollBy(0,600); y+=600; if(y>=document.body.scrollHeight){clearInterval(t);res();} },40); });
+});
+await page.waitForTimeout(1200);
+report.cls = await page.evaluate(() => window.__cls);
+report.transferredBytes = await page.evaluate(() =>
+  performance.getEntriesByType('resource').reduce((n, r) => n + (r.transferSize || 0), 0));
+report.resourceCount = await page.evaluate(() => performance.getEntriesByType('resource').length);
+await ctx.close();
+await browser.close();
+server.close();
+console.log(JSON.stringify(report, null, 2));

--- a/scripts/check-page.mjs
+++ b/scripts/check-page.mjs
@@ -186,6 +186,97 @@ check('the community layer is stated as donation-supported', 'the amended Q3 pos
     /donation/i.test(text) ? 'states donation-supported' : 'NO donation statement'];
 });
 
+
+// --- the cover grid ----------------------------------------------------------
+// Ticket #16 replaced twelve art-directed CSS tiles with real IGDB cover art.
+// Both states are legitimate — a cover withdrawn for any reason falls back to
+// the tile it replaced (docs/legal/igdb-image-licence-finding.md §7) — so every
+// assertion below holds in BOTH, and the pair of them pins the two states to
+// each other so the page can never show one and say the other.
+const COVER_IMGS = [...html.matchAll(/<img\b[^>]*\bsrc="\/covers\/[^"]+"[^>]*>/g)].map(m => m[0]);
+const attr = (tag, name) => tag.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1];
+
+check('every cover declares its intrinsic width and height', 'CLS stays 0.000', () => {
+  const bad = COVER_IMGS.filter(t => !/\bwidth="\d+"/.test(t) || !/\bheight="\d+"/.test(t));
+  return [bad.length === 0, `${COVER_IMGS.length} cover(s); ${bad.length} missing dimensions`];
+});
+
+check('every cover is lazy-loaded', 'the grid is section 6 of 16 — never above the fold', () => {
+  const bad = COVER_IMGS.filter(t => attr(t, 'loading') !== 'lazy');
+  return [bad.length === 0, `${bad.length} cover(s) not lazy`];
+});
+
+check('every cover is served from this origin', 'zero external requests', () => {
+  const bad = COVER_IMGS.filter(t => !(attr(t, 'src') ?? '').startsWith('/covers/'));
+  const srcsets = [...html.matchAll(/<source\b[^>]*\bsrcset="([^"]*)"/g)].map(m => m[1]);
+  const badSet = srcsets.filter(u => !u.startsWith('/covers/'));
+  return [bad.length === 0 && badSet.length === 0,
+    `${bad.length} off-origin img, ${badSet.length} off-origin source`];
+});
+
+check('cover alt text names each game and is distinct', 'twelve rows must not reach a reader as one string', () => {
+  const alts = COVER_IMGS.map(t => attr(t, 'alt') ?? '');
+  const empty = alts.filter(a => a.trim() === '').length;
+  const distinct = new Set(alts).size;
+  return [empty === 0 && distinct === alts.length,
+    `${alts.length} alt(s), ${distinct} distinct, ${empty} empty`];
+});
+
+check('no list element carries role="img"', 'ARIA-in-HTML — the aria-allowed-role fix of REDACTIONS §3.5', () => {
+  const bad = [...html.matchAll(/<(ul|ol|li)\b[^>]*\brole="img"/g)].map(m => m[0]);
+  return [bad.length === 0, bad.join(', ') || 'none'];
+});
+
+check('the cover disclosure matches what actually shipped', 'the page never credits a source it did not use', () => {
+  const shipped = COVER_IMGS.length > 0;
+  const saysIllustrative = /Cover tiles are illustrative artwork/.test(html);
+  const creditsIgdb = /Cover art from IGDB\.com/.test(html);
+  const ok = shipped ? (creditsIgdb && !saysIllustrative) : (saysIllustrative && !creditsIgdb);
+  return [ok, shipped
+    ? `${COVER_IMGS.length} real cover(s): credits IGDB ${creditsIgdb}, still says illustrative ${saysIllustrative}`
+    : `no real covers: says illustrative ${saysIllustrative}, credits IGDB ${creditsIgdb}`];
+});
+
+check('real cover art carries its attribution in the footer', 'IGDB fair attribution — visible, static location', () => {
+  const shipped = COVER_IMGS.length > 0;
+  const credited = /cover art on this page is from IGDB\.com/i.test(html);
+  return [shipped ? credited : !credited, shipped ? `credited: ${credited}` : 'no covers, no credit — correct'];
+});
+
+check('every mockup caption still discloses that it is not real', 'there is no runnable TUI to screenshot yet', () => {
+  // Deliberately broader than the word "mockup": §11's phone frames say
+  // "illustration … Not built yet", which is the same disclosure in different
+  // words and is not this ticket's to touch. What must never happen is a
+  // caption losing its disclosure entirely.
+  const captions = [...html.matchAll(/class="[^"]*z-mockup-caption[^"]*"[^>]*>([\s\S]*?)<\/figcaption>/g)]
+    .map(m => m[1].replace(/<[^>]+>/g, ' '));
+  const HONEST = /mockup|illustration|not a screenshot|not built yet|not available yet/i;
+  const bare = captions.filter(c => !HONEST.test(c));
+  return [captions.length > 0 && bare.length === 0,
+    `${captions.length} caption(s), ${bare.length} with no disclosure`];
+});
+
+// --- the copy file and the built page agree ---------------------------------
+// docs/content/landing-copy.md is the contract; the page is the artefact. A
+// reviewer checks them against each other by hand, so check them here instead —
+// every §06 cover alt string quoted in the copy file must appear verbatim in the
+// rendered page, and vice versa. Skipped (not failed) when the copy file is not
+// beside the build, so this stays runnable against a bare dist/.
+check('the copy file and the page agree on every cover alt string', 'the alt-text contract', () => {
+  const copyPath = 'docs/content/landing-copy.md';
+  if (!existsSync(copyPath)) return [true, 'copy file not present — skipped'];
+  const copy = readFileSync(copyPath, 'utf8');
+  const six = copy.slice(copy.indexOf('## 06 · one-collection'), copy.indexOf('## 07 ·'));
+  const declared = [...six.matchAll(/^\d{1,2}\. "([^"]+)"$/gm)].map(m => m[1]);
+  const decode = t => t.replace(/&#39;/g, "'").replace(/&amp;/g, '&').replace(/&quot;/g, '"');
+  const rendered = COVER_IMGS.map(t => decode(attr(t, 'alt') ?? ''));
+  if (rendered.length === 0) return [declared.length === 12, `no covers shipped; ${declared.length} declared`];
+  const missing = declared.filter(d => !rendered.includes(d));
+  const extra = rendered.filter(r => !declared.includes(r));
+  return [missing.length === 0 && extra.length === 0,
+    `${declared.length} declared, ${rendered.length} rendered; missing: ${missing.join(' | ') || 'none'}; unlisted: ${extra.join(' | ') || 'none'}`];
+});
+
 // --- report --------------------------------------------------------------
 let failed = 0;
 for (const r of results) {

--- a/scripts/fetch-covers.mjs
+++ b/scripts/fetch-covers.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * Fetch the twelve §06 cover images from IGDB and write them into the build.
+ *
+ * ONE PROVIDER. Every image on the landing page comes through this script and
+ * therefore through IGDB — including the `PHYSICAL` row, because `PHYSICAL` is
+ * a provenance label on the row and not a different image source. Nothing here
+ * reaches for a web search, and there is deliberately no code path that could.
+ * See `docs/legal/igdb-image-licence-finding.md`.
+ *
+ *   IGDB_CLIENT_ID=… IGDB_CLIENT_SECRET=… node scripts/fetch-covers.mjs
+ *
+ * Credentials are read from the environment and never written anywhere. The
+ * outputs are:
+ *
+ *   site/public/covers/{slug}.avif|.webp|.jpg   — 360 × 480, centre-cropped
+ *   docs/legal/cover-provenance.json            — what each file came from
+ *
+ * Re-runnable: existing files are overwritten, and `--check` reports what the
+ * build currently contains without touching the network.
+ *
+ * The only dependency is sharp, which Astro already installs — see
+ * site/package-lock.json. Nothing new enters the dependency tree for this.
+ */
+import { createRequire } from 'node:module';
+import { mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(new URL('../site/package.json', import.meta.url));
+
+const ROOT = new URL('../', import.meta.url);
+const OUT_DIR = new URL('site/public/covers/', ROOT);
+const PROVENANCE = new URL('docs/legal/cover-provenance.json', ROOT);
+
+// Kept in step with site/src/data/coverGrid.ts by `--check`, which fails when
+// the two disagree — the data file is the source of truth for which twelve.
+const WIDTH = 360;
+const HEIGHT = 480;
+
+/** Parse the row table straight out of the TypeScript so there is exactly one
+ *  list of the twelve and this script cannot drift from what the page renders. */
+async function rows() {
+  const src = await import('node:fs').then((fs) =>
+    fs.readFileSync(fileURLToPath(new URL('site/src/data/coverGrid.ts', ROOT)), 'utf8')
+  );
+  const out = [];
+  const re =
+    /searchName:\s*'((?:[^'\\]|\\.)*)'[\s\S]*?releaseYear:\s*(\d{4}),\s*slug:\s*'([a-z0-9-]+)'/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    out.push({ searchName: m[1].replace(/\\'/g, "'"), releaseYear: Number(m[2]), slug: m[3] });
+  }
+  return out;
+}
+
+function report(list) {
+  const present = list.filter((r) => existsSync(new URL(`${r.slug}.jpg`, OUT_DIR)));
+  console.log(`${present.length}/${list.length} covers present in site/public/covers/`);
+  for (const r of list) {
+    const ok = existsSync(new URL(`${r.slug}.jpg`, OUT_DIR));
+    console.log(`  ${ok ? '✓' : '·'} ${r.slug}${ok ? '' : '  (renders the art-directed tile)'}`);
+  }
+  return present.length;
+}
+
+async function token(id, secret) {
+  const u = new URL('https://id.twitch.tv/oauth2/token');
+  u.searchParams.set('client_id', id);
+  u.searchParams.set('client_secret', secret);
+  u.searchParams.set('grant_type', 'client_credentials');
+  const r = await fetch(u, { method: 'POST' });
+  if (!r.ok) throw new Error(`Twitch OAuth failed: ${r.status} ${await r.text()}`);
+  return (await r.json()).access_token;
+}
+
+async function igdb(body, id, tok) {
+  const r = await fetch('https://api.igdb.com/v4/games', {
+    method: 'POST',
+    headers: { 'Client-ID': id, Authorization: `Bearer ${tok}`, Accept: 'application/json' },
+    body
+  });
+  if (!r.ok) throw new Error(`IGDB query failed: ${r.status} ${await r.text()}`);
+  return r.json();
+}
+
+const yearOf = (g) =>
+  g.first_release_date ? new Date(g.first_release_date * 1000).getUTCFullYear() : null;
+
+/**
+ * Deterministic match, and it refuses rather than guesses.
+ *
+ * A fuzzy "closest result wins" is how a page ends up quietly showing the 2023
+ * Dead Space remake under a row that claims to be the 2008 original. So: exact
+ * name match first, then the release year from the data file, and if that does
+ * not land on exactly one game the row is REPORTED and skipped — it renders its
+ * art-directed tile and a human pins the id. A wrong cover is worse than none.
+ */
+function pick(results, row) {
+  const named = results.filter(
+    (g) => g.name && g.name.toLowerCase() === row.searchName.toLowerCase()
+  );
+  const pool = named.length ? named : results;
+  const dated = pool.filter((g) => yearOf(g) === row.releaseYear);
+  if (dated.length === 1) return dated[0];
+  if (named.length === 1 && !dated.length) return named[0];
+  if (dated.length > 1) {
+    // Same name, same year, more than one entry: prefer the parent game
+    // (a main game has no `parent_game`), which is the edition a player means.
+    const parents = dated.filter((g) => !g.parent_game);
+    if (parents.length === 1) return parents[0];
+  }
+  return null;
+}
+
+async function main() {
+  const list = await rows();
+  if (list.length !== 12) {
+    console.error(`Expected 12 rows in site/src/data/coverGrid.ts, parsed ${list.length}.`);
+    process.exit(1);
+  }
+
+  if (process.argv.includes('--check')) {
+    report(list);
+    return;
+  }
+
+  const id = process.env.IGDB_CLIENT_ID;
+  const secret = process.env.IGDB_CLIENT_SECRET;
+  if (!id || !secret) {
+    console.error(
+      'IGDB_CLIENT_ID and IGDB_CLIENT_SECRET are not set.\n\n' +
+        'Register a Confidential application at https://dev.twitch.tv/console/apps\n' +
+        '(OAuth redirect http://localhost), generate a secret, then:\n\n' +
+        '  IGDB_CLIENT_ID=… IGDB_CLIENT_SECRET=… node scripts/fetch-covers.mjs\n\n' +
+        'Without them the page renders the art-directed tiles, which is a valid\n' +
+        'shipping state — see docs/legal/igdb-image-licence-finding.md §7.'
+    );
+    process.exit(2);
+  }
+
+  const sharp = require('sharp');
+  mkdirSync(fileURLToPath(OUT_DIR), { recursive: true });
+
+  const tok = await token(id, secret);
+  const provenance = {
+    source: 'IGDB (api.igdb.com/v4), served under the Twitch Developer Services Agreement',
+    finding: 'docs/legal/igdb-image-licence-finding.md',
+    fetchedAt: new Date().toISOString(),
+    rendered: { width: WIDTH, height: HEIGHT, fit: 'cover', position: 'centre' },
+    covers: []
+  };
+
+  let failed = 0;
+  for (const row of list) {
+    const q =
+      `search "${row.searchName.replace(/"/g, '\\"')}"; ` +
+      'fields name,slug,first_release_date,parent_game,cover.image_id,cover.width,cover.height; ' +
+      'where cover != null; limit 25;';
+    const results = await igdb(q, id, tok);
+    const game = pick(results, row);
+
+    if (!game || !game.cover?.image_id) {
+      failed++;
+      console.error(
+        `✗ ${row.slug}: no unambiguous IGDB match for "${row.searchName}" (${row.releaseYear}). ` +
+          `Candidates: ${results.map((g) => `${g.name} [${yearOf(g) ?? '?'}]`).join(', ') || 'none'}`
+      );
+      continue;
+    }
+
+    // 528 × 748 — the largest cover IGDB publishes, downscaled here rather than
+    // upscaled later.
+    const src = `https://images.igdb.com/igdb/image/upload/t_cover_big_2x/${game.cover.image_id}.jpg`;
+    const res = await fetch(src);
+    if (!res.ok) {
+      failed++;
+      console.error(`✗ ${row.slug}: cover download failed, ${res.status} ${src}`);
+      continue;
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+
+    // The centre crop that takes IGDB's 0.706 to the ratified 0.750 box. Doing
+    // it here means the shipped file's intrinsic size IS the rendered box, so
+    // the width/height attributes are true and CLS stays 0.000.
+    const base = sharp(buf).resize(WIDTH, HEIGHT, { fit: 'cover', position: 'centre' });
+    await Promise.all([
+      base.clone().jpeg({ quality: 82, mozjpeg: true }).toFile(fileURLToPath(new URL(`${row.slug}.jpg`, OUT_DIR))),
+      base.clone().webp({ quality: 80 }).toFile(fileURLToPath(new URL(`${row.slug}.webp`, OUT_DIR))),
+      base.clone().avif({ quality: 55 }).toFile(fileURLToPath(new URL(`${row.slug}.avif`, OUT_DIR)))
+    ]);
+
+    provenance.covers.push({
+      slug: row.slug,
+      igdbGameId: game.id,
+      igdbSlug: game.slug,
+      igdbName: game.name,
+      releaseYear: yearOf(game),
+      igdbCoverImageId: game.cover.image_id,
+      sourceUrl: src
+    });
+    console.log(`✓ ${row.slug}  ← ${game.name} [${yearOf(game)}]  ${game.cover.image_id}`);
+  }
+
+  provenance.covers.sort((a, b) => a.slug.localeCompare(b.slug));
+  writeFileSync(fileURLToPath(PROVENANCE), `${JSON.stringify(provenance, null, 2)}\n`);
+
+  const written = readdirSync(fileURLToPath(OUT_DIR)).filter((f) => f.endsWith('.jpg')).length;
+  console.log(`\n${written}/12 covers written to site/public/covers/`);
+  console.log(`Provenance recorded in docs/legal/cover-provenance.json`);
+  if (failed) {
+    console.error(
+      `\n${failed} row(s) unresolved — they render the art-directed tile. Pin them by hand ` +
+        `rather than loosening the match.`
+    );
+    process.exit(1);
+  }
+}
+
+await main();

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -47,6 +47,15 @@
 /fonts/*
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400
 
+# Game cover art fetched from IGDB and served from this origin — the page makes
+# zero external requests and that includes these. Not content-hashed, and IGDB
+# does replace cover art (its docs note a 30-day window on a replaced image), so
+# the same stale-while-revalidate shape as the fonts rather than `immutable`:
+# a re-fetched cover under an unchanged filename must not be served stale for a
+# year. See docs/legal/igdb-image-licence-finding.md §3.2.
+/covers/*
+  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
+
 # Same-origin marks/icons — also unhashed, same reasoning, shorter floor
 # since these are tiny and revalidation is cheap.
 /*.svg

--- a/site/src/components/CoverGrid.astro
+++ b/site/src/components/CoverGrid.astro
@@ -1,31 +1,90 @@
 ---
 /**
- * CoverGrid — twelve CoverTiles, role="img" labelled by its caption.
- * Ref: design/blueprint.md §7.5.
+ * CoverGrid — the twelve covers of §06.
+ *
+ * Two accessible shapes, picked by what the build actually contains:
+ *
+ * - **Covers present** — a `<ul>` of twelve images, each with its own alt text
+ *   naming the game and its platform. The ratified design specified
+ *   `role="img"` with `aria-hidden` children, and that was right for twelve
+ *   decorative gradients: there was one thing to say and saying it twelve times
+ *   would have been noise. Real covers are not decorative — each one is a
+ *   distinct piece of information, and a `role="img"` container would hide all
+ *   twelve from assistive technology. So the role goes and the list stays, which
+ *   is what still lets a screen-reader user hear "list, 12 items" and skip past.
+ *   Recorded as an amendment in `docs/design/blueprint.md` §7.5.
+ *
+ * - **No covers in the build** — the original ratified behaviour, unchanged:
+ *   `role="img"` labelled by the caption, children hidden, one description.
+ *
+ * The check is a filesystem read at build time rather than a flag, so the page
+ * can never claim to show cover art it did not ship.
+ *
+ * Ref: design/blueprint.md §7.5, content/landing-copy.md §06.
  *
  * @prop {string} labelledby — id of the figcaption describing this figure
  */
 import CoverTile from './CoverTile.astro';
-import { COVER_GRID_SEQUENCE } from '../data/coverGrid';
+import { coverTiles } from '../data/coverAssets';
 
 interface Props {
   labelledby: string;
 }
 
 const { labelledby } = Astro.props;
+
+const tiles = coverTiles();
+const anyImages = tiles.some((t) => t.hasImage);
 ---
 
-<div class="z-cover-grid" role="img" aria-labelledby={labelledby}>
-  {COVER_GRID_SEQUENCE.map((tile) => (
-    <CoverTile treatment={tile.treatment} hue={tile.hue} platformTag={tile.platformTag} />
-  ))}
-</div>
+{/* Two different elements on purpose, because the two states have genuinely
+    different semantics and neither may borrow the other's markup.
+
+    With covers: a real <ul> of twelve labelled images. No role override —
+    ARIA-in-HTML does not permit role="img" on a <ul>, and putting it there
+    would re-break the `aria-allowed-role` audit this page already fixed once
+    (docs/REDACTIONS.md §3.5).
+
+    Without covers: exactly the ratified shape — a <div role="img"> labelled by
+    the caption, decorative children hidden. Unchanged from rev A. */}
+{anyImages ? (
+  <ul class="z-cover-grid">
+    {tiles.map((tile) => (
+      <CoverTile
+        asListItem={true}
+        treatment={tile.treatment}
+        hue={tile.hue}
+        platformTag={tile.platformTag}
+        slug={tile.slug}
+        alt={tile.alt}
+        hasImage={tile.hasImage}
+      />
+    ))}
+  </ul>
+) : (
+  <div class="z-cover-grid" role="img" aria-labelledby={labelledby}>
+    {tiles.map((tile) => (
+      <CoverTile
+        asListItem={false}
+        treatment={tile.treatment}
+        hue={tile.hue}
+        platformTag={tile.platformTag}
+        slug={tile.slug}
+        alt={tile.alt}
+        hasImage={false}
+      />
+    ))}
+  </div>
+)}
 
 <style>
   .z-cover-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: var(--z-space-3);
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
   @media (min-width: 768px) {

--- a/site/src/components/CoverTile.astro
+++ b/site/src/components/CoverTile.astro
@@ -1,22 +1,41 @@
 ---
 /**
- * CoverTile — one art-directed tile of the twelve. No real cover art; four
- * CSS treatments × three hue keys. Non-interactive: no hover, no link.
- * Ref: design/blueprint.md §7.5.
+ * CoverTile — one row of the twelve.
+ *
+ * Renders the real IGDB cover when this row's image files are present, and the
+ * original art-directed CSS treatment when they are not. Both states are
+ * first-class: a cover withdrawn for any reason (see
+ * `docs/legal/igdb-image-licence-finding.md` §7) degrades to the tile it
+ * replaced without touching the layout.
+ *
+ * Non-interactive: no hover, no link, no lightbox.
+ * Ref: design/blueprint.md §7.5 (as amended 2026-08-25).
  *
  * @prop {import('../data/coverGrid').Treatment} treatment
  * @prop {import('../data/coverGrid').Hue} hue
  * @prop {import('../data/coverGrid').PlatformTagKind} platformTag
+ * @prop {string} slug  — basename of /covers/{slug}.avif|.webp|.jpg
+ * @prop {string} alt   — names the game and its platform; distinct per tile
+ * @prop {boolean} hasImage — whether this row's files exist in the build
+ * @prop {boolean} asListItem — <li> inside the <ul> when covers ship; <div>
+ *   inside the ratified role="img" container when they do not
  */
 import PlatformTag from './PlatformTag.astro';
+import { COVER_WIDTH, COVER_HEIGHT } from '../data/coverGrid';
 
 interface Props {
   treatment: 'A' | 'B' | 'C' | 'D';
   hue: 'amber' | 'cyan' | 'steel' | 'orchid';
   platformTag: 'STEAM' | 'GOG' | 'EA' | 'PS' | 'PHYSICAL';
+  slug: string;
+  alt: string;
+  hasImage: boolean;
+  asListItem: boolean;
 }
 
-const { treatment, hue, platformTag } = Astro.props;
+const { treatment, hue, platformTag, slug, alt, hasImage, asListItem } = Astro.props;
+
+const Tag = asListItem ? 'li' : 'div';
 
 const HUE_TOKEN: Record<string, string> = {
   amber: '--z-primary',
@@ -27,12 +46,43 @@ const HUE_TOKEN: Record<string, string> = {
 const hueVar = `var(${HUE_TOKEN[hue]})`;
 ---
 
-<div class={`z-tile z-tile--${treatment}`} style={`--z-tile-hue: ${hueVar}`} aria-hidden="true">
-  <div class="z-tile__art"></div>
-  <div class="z-tile__tag">
+{/* The tile is a list item so a screen reader is told how many covers there
+    are and can step past them; twelve loose images in a row is the thing that
+    makes a grid like this tedious to listen to. A tile with no image carries
+    no information at all, so it is hidden outright rather than announced as an
+    empty item. */}
+<Tag
+  class={`z-tile z-tile--${treatment}`}
+  style={`--z-tile-hue: ${hueVar}`}
+  aria-hidden={hasImage ? undefined : 'true'}
+>
+  {hasImage ? (
+    <picture>
+      <source srcset={`/covers/${slug}.avif`} type="image/avif" />
+      <source srcset={`/covers/${slug}.webp`} type="image/webp" />
+      {/* width/height are the files' true intrinsic size, and the tile box is
+          already reserved by `aspect-ratio` — between them CLS stays 0.000.
+          The grid sits in section 6 of 16, well below the fold on every
+          viewport, so every cover is lazy; nothing above the fold is. */}
+      <img
+        class="z-tile__img"
+        src={`/covers/${slug}.jpg`}
+        alt={alt}
+        width={COVER_WIDTH}
+        height={COVER_HEIGHT}
+        loading="lazy"
+        decoding="async"
+      />
+    </picture>
+  ) : (
+    <div class="z-tile__art"></div>
+  )}
+  {/* Decorative on purpose: the platform is already named in the cover's alt
+      text, so announcing the plate as well would say it twice. */}
+  <div class="z-tile__tag" aria-hidden="true">
     <PlatformTag kind={platformTag} />
   </div>
-</div>
+</Tag>
 
 <style>
   .z-tile {
@@ -41,11 +91,25 @@ const hueVar = `var(${HUE_TOKEN[hue]})`;
     background: var(--z-void);
     border-radius: var(--z-radius-sm);
     overflow: hidden;
+    list-style: none;
   }
 
   .z-tile__art {
     position: absolute;
     inset: 0;
+  }
+
+  /* Fills the ratified 3 / 4 box. The file is already cropped to 3 / 4 at fetch
+     time, so `cover` has nothing left to crop — it is here so a source that
+     ever arrives at a different ratio fills the box instead of distorting. */
+  .z-tile__img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
   }
 
   .z-tile__tag {

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -6,10 +6,17 @@
  */
 import FooterLink from './FooterLink.astro';
 import PoweredByFlowForge from './PoweredByFlowForge.astro';
+import { hasRealCovers } from '../data/coverAssets';
 
 const WAITLIST = 'mailto:alex@flowforgesoft.com?subject=Zerado-WaitList';
 const CONTACT = 'mailto:alex@flowforgesoft.com';
 const GITHUB = 'https://github.com/JustCode-CruzAlex/Zerado';
+
+// Second half of the IGDB attribution — visible and in a static location, per
+// docs/legal/igdb-image-licence-finding.md §6. It appears only when covers
+// actually ship, so the page never credits a source it did not use. Plain text,
+// not a link: the page's zero-external-request guarantee is load-bearing.
+const realCovers = hasRealCovers();
 ---
 
 <footer role="contentinfo" id="footer" class="z-footer z-section z-section--surface">
@@ -30,6 +37,13 @@ const GITHUB = 'https://github.com/JustCode-CruzAlex/Zerado';
         page, nothing here is for sale, and there is no funding ask anywhere on it. The Phase 4
         community layer will be donation-supported when it exists.
       </p>
+      {realCovers && (
+        <p class="z-body-sm">
+          Game cover art on this page is from IGDB.com, used under the Twitch Developer Services
+          Agreement. Zerado is not affiliated with IGDB, Twitch, or any game publisher, and each
+          cover remains the property of its rights holder.
+        </p>
+      )}
     </div>
 
     <div class="z-footer__band z-footer__band--company">

--- a/site/src/data/coverAssets.ts
+++ b/site/src/data/coverAssets.ts
@@ -1,0 +1,42 @@
+/**
+ * What the build actually contains, read from disk at build time.
+ *
+ * Every statement the page makes about its cover art — the twelve `<img>`
+ * elements, the caption under the grid, and the IGDB credit in the footer — is
+ * derived from this one function. The page therefore cannot credit a source it
+ * did not ship from, and cannot disclose "illustrative artwork" while showing
+ * real covers. The two states stay consistent because they read the same fact
+ * rather than two flags someone has to remember to flip together.
+ *
+ * Ref: docs/legal/igdb-image-licence-finding.md §6 (attribution) and §7 (the
+ * reversal path this makes cheap).
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { COVER_GRID_SEQUENCE, type CoverTileDef } from './coverGrid';
+
+export interface CoverTileState extends CoverTileDef {
+  hasImage: boolean;
+}
+
+// Resolved against the working directory, not `import.meta.url`: this module is
+// bundled before it runs, so `import.meta.url` points at the emitted chunk and
+// a relative walk from it lands nowhere near `public/`. The build runs from
+// `site/` (`npm run build`, and `working-directory: site` in CI); the second
+// candidate covers a run from the repository root.
+const COVERS_DIR =
+  [resolve(process.cwd(), 'public/covers'), resolve(process.cwd(), 'site/public/covers')].find(
+    (d) => existsSync(d)
+  ) ?? resolve(process.cwd(), 'public/covers');
+
+export function coverTiles(): CoverTileState[] {
+  return COVER_GRID_SEQUENCE.map((tile) => ({
+    ...tile,
+    hasImage: existsSync(resolve(COVERS_DIR, `${tile.slug}.jpg`))
+  }));
+}
+
+/** True when at least one real cover ships — the trigger for crediting IGDB. */
+export function hasRealCovers(): boolean {
+  return coverTiles().some((t) => t.hasImage);
+}

--- a/site/src/data/coverGrid.ts
+++ b/site/src/data/coverGrid.ts
@@ -1,30 +1,144 @@
 /**
- * The twelve art-directed cover tiles — fixed sequence, treatment × hue,
- * never real game cover art. Ref: design/blueprint.md §7.5,
- * blueprint.tokens.json coverGrid.sequence (verbatim).
+ * The twelve rows of the §06 shelf grid.
+ *
+ * Every image is fetched from IGDB by `scripts/fetch-covers.mjs` and served
+ * from this repository — no hotlink, no web-sourced artwork, one provider and
+ * therefore one licence question. See
+ * `docs/legal/igdb-image-licence-finding.md`.
+ *
+ * `platformTag` is a PROVENANCE label on the row, not a second image source: a
+ * SNES cartridge has an IGDB entry exactly as a Steam title does, and Zerado
+ * will fetch a physical copy's cover the same way it fetches a synced one.
+ *
+ * The per-position `treatment` × `hue` sequence is UNCHANGED from the ratified
+ * design and is still the renderer for any row whose image file is absent — a
+ * cover pulled for any reason degrades to the tile it replaced, and nothing
+ * else on the page moves. Ref: `docs/design/blueprint.md` §7.5 (as amended
+ * 2026-08-25), `blueprint.tokens.json` coverGrid.sequence.
  */
 export type Treatment = 'A' | 'B' | 'C' | 'D';
 export type Hue = 'amber' | 'cyan' | 'steel' | 'orchid';
 export type PlatformTagKind = 'STEAM' | 'GOG' | 'EA' | 'PS' | 'PHYSICAL';
 
 export interface CoverTileDef {
+  /** Position in the ratified sequence, 1–12. */
   n: number;
+  /** Art-directed fallback treatment, used when this row has no image file. */
   treatment: Treatment;
+  /** Art-directed fallback hue key. */
   hue: Hue;
+  /** The plate rendered bottom-left. A provenance label, not an image source. */
   platformTag: PlatformTagKind;
+  /** The game, as a reader would name it. */
+  title: string;
+  /** What `searchName` IGDB is asked for. Kept separate from `title` so the
+   *  displayed name never has to bend to match a database's spelling. */
+  searchName: string;
+  /** The year of the release we mean. Pins the match: "Dead Space" alone would
+   *  as happily resolve to the 2023 remake, and "God of War" to the 2005 one. */
+  releaseYear: number;
+  /** Basename of the served files: `/covers/{slug}.avif|.webp|.jpg`. */
+  slug: string;
+  /** Alt text. Names the game AND its platform; all twelve are distinct.
+   *  Mirrored verbatim in `docs/content/landing-copy.md` §06. */
+  alt: string;
 }
 
+/**
+ * The twelve, chosen against three constraints: they carry the platform tags
+ * the grid already asserts (6 STEAM · 2 GOG · 1 EA · 2 PS · 1 PHYSICAL, with
+ * PHYSICAL at position 9 exactly as ratified); they span 1994–2020 so the
+ * retro and physical case reads as deliberate rather than accidental; and each
+ * one is a title the audience recognises on sight. The per-position
+ * platform-tag mapping is unchanged from the ratified sequence.
+ */
 export const COVER_GRID_SEQUENCE: CoverTileDef[] = [
-  { n: 1, treatment: 'A', hue: 'amber', platformTag: 'STEAM' },
-  { n: 2, treatment: 'B', hue: 'cyan', platformTag: 'STEAM' },
-  { n: 3, treatment: 'C', hue: 'steel', platformTag: 'GOG' },
-  { n: 4, treatment: 'D', hue: 'orchid', platformTag: 'STEAM' },
-  { n: 5, treatment: 'B', hue: 'amber', platformTag: 'PS' },
-  { n: 6, treatment: 'A', hue: 'cyan', platformTag: 'STEAM' },
-  { n: 7, treatment: 'D', hue: 'steel', platformTag: 'EA' },
-  { n: 8, treatment: 'C', hue: 'orchid', platformTag: 'STEAM' },
-  { n: 9, treatment: 'B', hue: 'orchid', platformTag: 'PHYSICAL' },
-  { n: 10, treatment: 'A', hue: 'steel', platformTag: 'GOG' },
-  { n: 11, treatment: 'D', hue: 'amber', platformTag: 'PS' },
-  { n: 12, treatment: 'C', hue: 'cyan', platformTag: 'STEAM' }
+  {
+    n: 1, treatment: 'A', hue: 'amber', platformTag: 'STEAM',
+    title: 'Half-Life 2', searchName: 'Half-Life 2', releaseYear: 2004, slug: 'half-life-2',
+    alt: 'Half-Life 2 — cover art, in the Steam part of the library'
+  },
+  {
+    n: 2, treatment: 'B', hue: 'cyan', platformTag: 'STEAM',
+    title: 'Hades', searchName: 'Hades', releaseYear: 2020, slug: 'hades',
+    alt: 'Hades — cover art, in the Steam part of the library'
+  },
+  {
+    n: 3, treatment: 'C', hue: 'steel', platformTag: 'GOG',
+    title: 'The Witcher 3: Wild Hunt', searchName: 'The Witcher 3: Wild Hunt',
+    releaseYear: 2015, slug: 'the-witcher-3-wild-hunt',
+    alt: 'The Witcher 3: Wild Hunt — cover art, in the GOG part of the library'
+  },
+  {
+    n: 4, treatment: 'D', hue: 'orchid', platformTag: 'STEAM',
+    title: 'Portal 2', searchName: 'Portal 2', releaseYear: 2011, slug: 'portal-2',
+    alt: 'Portal 2 — cover art, in the Steam part of the library'
+  },
+  {
+    n: 5, treatment: 'B', hue: 'amber', platformTag: 'PS',
+    title: 'Bloodborne', searchName: 'Bloodborne', releaseYear: 2015, slug: 'bloodborne',
+    alt: 'Bloodborne — cover art, in the PlayStation part of the library'
+  },
+  {
+    n: 6, treatment: 'A', hue: 'cyan', platformTag: 'STEAM',
+    title: 'Stardew Valley', searchName: 'Stardew Valley', releaseYear: 2016, slug: 'stardew-valley',
+    alt: 'Stardew Valley — cover art, in the Steam part of the library'
+  },
+  {
+    n: 7, treatment: 'D', hue: 'steel', platformTag: 'EA',
+    title: 'Dead Space', searchName: 'Dead Space', releaseYear: 2008, slug: 'dead-space',
+    alt: 'Dead Space — cover art, in the EA part of the library'
+  },
+  {
+    n: 8, treatment: 'C', hue: 'orchid', platformTag: 'STEAM',
+    title: 'Celeste', searchName: 'Celeste', releaseYear: 2018, slug: 'celeste',
+    alt: 'Celeste — cover art, in the Steam part of the library'
+  },
+  {
+    // The one hand-added row. Its cover comes from IGDB exactly like the other
+    // eleven — PHYSICAL describes where the copy lives, not where the art came
+    // from. This is the tile the whole section argues about.
+    n: 9, treatment: 'B', hue: 'orchid', platformTag: 'PHYSICAL',
+    title: 'Super Metroid', searchName: 'Super Metroid', releaseYear: 1994, slug: 'super-metroid',
+    alt: 'Super Metroid — cover art, a SNES cartridge added to the library by hand'
+  },
+  {
+    n: 10, treatment: 'A', hue: 'steel', platformTag: 'GOG',
+    title: 'Baldur’s Gate II: Shadows of Amn',
+    searchName: 'Baldur’s Gate II: Shadows of Amn',
+    releaseYear: 2000, slug: 'baldurs-gate-ii-shadows-of-amn',
+    alt: 'Baldur’s Gate II: Shadows of Amn — cover art, in the GOG part of the library'
+  },
+  {
+    n: 11, treatment: 'D', hue: 'amber', platformTag: 'PS',
+    title: 'God of War', searchName: 'God of War', releaseYear: 2018, slug: 'god-of-war',
+    alt: 'God of War — cover art, in the PlayStation part of the library'
+  },
+  {
+    n: 12, treatment: 'C', hue: 'cyan', platformTag: 'STEAM',
+    title: 'Hollow Knight', searchName: 'Hollow Knight', releaseYear: 2017, slug: 'hollow-knight',
+    alt: 'Hollow Knight — cover art, in the Steam part of the library'
+  }
 ];
+
+/**
+ * Rendered at 3 / 4 — the ratified tile geometry, unchanged.
+ *
+ * IGDB serves covers at 264 × 374 (`t_cover_big`, or 528 × 748 at `_2x`), which
+ * is 0.706 rather than 0.750. **Aspect-ratio policy: one uniform 3 / 4 box, a
+ * centred crop taken at fetch time, never a letterbox and never a per-tile
+ * ratio.** The crop removes about 3% from the top and 3% from the bottom of the
+ * source, which box art tolerates; a letterbox would have put twelve different
+ * pillar colours into a six-colour palette, and per-tile ratios would have made
+ * the rows ragged — the exact failure the ticket named. The files are written
+ * at these dimensions so the `width`/`height` attributes on every `<img>` are
+ * the file's true intrinsic size and CLS stays 0.000.
+ *
+ * **Sized to the RENDERED box, not to the source.** Measured with Playwright,
+ * a tile is 104 CSS px wide at 375, 168 at 768 and 175 at 1280 and above — so
+ * 350 px covers the widest tile on a DPR 2 display, and 360 × 480 is the
+ * nearest exact 3 / 4 above it. Shipping IGDB's full 528 × 748 would have been
+ * roughly 2.2× the pixels for something no display can resolve.
+ */
+export const COVER_WIDTH = 360;
+export const COVER_HEIGHT = 480;

--- a/site/src/sections/OneCollection.astro
+++ b/site/src/sections/OneCollection.astro
@@ -8,6 +8,14 @@ import SectionEyebrow from '../components/SectionEyebrow.astro';
 import SectionHeading from '../components/SectionHeading.astro';
 import StoreRow from '../components/StoreRow.astro';
 import CoverGrid from '../components/CoverGrid.astro';
+import { hasRealCovers } from '../data/coverAssets';
+
+// The caption states what the build actually contains. With real covers it
+// credits IGDB (docs/legal/igdb-image-licence-finding.md §6 — visible, static,
+// the shape IGDB describes as fair attribution); with none it keeps the
+// original disclosure, which is the honest line for art-directed tiles. There
+// is no state in which the page shows one and says the other.
+const realCovers = hasRealCovers();
 ---
 
 <section id="one-collection" aria-labelledby="one-collection-heading" class="z-section z-section--surface">
@@ -53,7 +61,9 @@ import CoverGrid from '../components/CoverGrid.astro';
           same collection as everything else.
         </span>
         <span class="z-one-collection__tile-disclosure">
-          Cover tiles are illustrative artwork, not real game covers.
+          {realCovers
+            ? 'Cover art from IGDB.com. The library view itself is a mockup.'
+            : 'Cover tiles are illustrative artwork, not real game covers.'}
         </span>
       </figcaption>
     </figure>


### PR DESCRIPTION
Closes #16

## The one thing that decided this ticket

I read the terms before touching an image. The finding is committed at
[`docs/legal/igdb-image-licence-finding.md`](../blob/feature/16-worker/docs/legal/igdb-image-licence-finding.md) — every source quoted, with its URL and the date read.

**It is not a blanket "yes", and it is not the "non-commercial makes this fine" the ticket warned about.** It splits in two:

**On the narrow question the ticket actually asked — marketing website vs. inside the application — the terms answer favourably, and explicitly.** TDSA §II.A.1 defines an App to include a **website**; §II.B.2.i licenses use of Program Materials to *"develop, test, **promote**, measure, support, and operate Your Services"*. Promotion is an enumerated licensed purpose, and nothing in the TDSA or the IGDB docs confines use to the interior of a shipped app. The distinction this ticket was right to insist on **does not cut against us.**

**The distinction that actually matters is a different one, and no document in the chain resolves it.** Twitch's grant is expressly **non-sublicensable** (§II.B.2), the materials are the property of *"Twitch **or its licensors**"* with all rights not granted reserved (§III.A), supplied **AS IS with all warranties disclaimed** (§X.D) — while §XI.B/§XI.E put the burden of having obtained every third-party right on us, and §X.E(iii) has us indemnify Twitch for claims arising from exactly the **promotion** of our services. And IGDB's own Image Policy accepts cover uploads on a **fair use** basis, so IGDB neither holds nor can pass on the publisher's copyright.

> **IGDB and Twitch permit this use, including on a marketing page. Neither clears the publisher's copyright, neither claims to, and the TDSA assigns that residual to Zerado.**

The founder was shown that shape and took the decision on 2026-08-25 on Zerado's non-commercial, zero-revenue, donation-only, open-source posture. It is recorded as a risk-acceptance decision, with the reversal path, so it reads as a decision taken with the residual in view. The IGDB email folding **both** questions into one message is drafted at [`docs/legal/igdb-email-2026-08-25.md`](../blob/feature/16-worker/docs/legal/igdb-email-2026-08-25.md).

## ⏸ One thing is blocked, and it is the image bytes

**The IGDB API needs a Twitch Client ID + Secret. There are none** — not in the environment, not in the repo, not in this repository's GitHub secrets or variables. Every route to a cover image hash goes through an authenticated `api.igdb.com/v4` call. It needs a human with a Twitch account and 2FA (~3 min): [dev.twitch.tv/console/apps](https://dev.twitch.tv/console/apps) → Register (Confidential, redirect `http://localhost`) → New Secret. Details in [the ticket comment](https://github.com/JustCode-CruzAlex/Zerado/issues/16#issuecomment-5414734270).

**Everything else is done.** When the credentials land it is one command and a data-only commit on this same branch:

```bash
IGDB_CLIENT_ID=… IGDB_CLIENT_SECRET=… node scripts/fetch-covers.mjs
```

**So this PR currently ships the art-directed tiles** — deliberately, not as a gap. The page is honest in that state and loses nothing, exactly as the ticket said it should.

## The page is honest in both states, by construction

The build reads `site/public/covers/` and states what it actually contains. There is no flag anyone has to remember to flip:

| | Grid markup | Caption under the grid | Footer |
|---|---|---|---|
| **Covers present** | `<ul>` of 12 images, distinct alt each | *"Cover art from IGDB.com. The library view itself is a mockup."* | IGDB credit |
| **No covers** | ratified `<div role="img">`, children hidden | *"Cover tiles are illustrative artwork, not real game covers."* | no credit |

`check-page.mjs` asserts the two can never disagree — and asserts the twelve alt strings in `docs/content/landing-copy.md` appear **verbatim** in the built page, which is the cross-check a reviewer would otherwise do by hand.

## I pushed back on one part of the plan, and the founder agreed

Sourcing the physical covers "from the web" was the one path with **no licence at all** — strictly worse than the tiles being replaced. `PHYSICAL` is now a **provenance label on the row, not a different image source**: a SNES cartridge (Super Metroid, tile 9) has an IGDB entry exactly as a Steam title does. One licence question instead of two, and it is what the product will actually do. `fetch-covers.mjs` has no code path that could reach a web search.

## Evidence — measured, reproducible

Full detail and re-run commands: [`docs/qa/cover-grid-evidence.md`](../blob/feature/16-worker/docs/qa/cover-grid-evidence.md). With-covers figures used synthetic stand-ins at the real dimensions and a realistic compression profile (360×480, AVIF ≈22 KB) since credentials had not arrived; **none were committed.**

**Lighthouse 12** — every category ≥ 95, CLS 0 on both form factors:

| | Perf | A11y | Best pr. | SEO | CLS | LCP |
|---|---|---|---|---|---|---|
| Desktop · with covers | **100** | **100** | **100** | **100** | **0** | 0.5 s |
| Mobile · with covers | **99** | **100** | **100** | **100** | **0** | 2.0 s |
| Mobile · fallback | 99 | 100 | 100 | 100 | 0 | 2.0 s |

The mobile 99 is **not the covers** — the fallback build scores 99 with the same 2.0 s LCP under the same conditions. It is this machine against the published live 100. Total mobile byte weight stays **176 KiB** because the twelve covers are never fetched during the run: they are all below the fold and lazy, and `offscreen-images` passes.

**axe-core** (`wcag2a wcag2aa wcag21a wcag21aa`, after full scroll) — **0 violations** at 375 / 768 / 1280 / 1920 in **both** states, and **0 external requests** at every viewport.

**Geometry** — one width and one height per viewport, rows always divide evenly, **no ragged row anywhere**:

| Viewport | Rows | Tile | Ratio |
|---|---|---|---|
| 375 | 3·3·3·3 | 104×138 | 0.754 |
| 768 | 4·4·4 | 168×224 | 0.750 |
| 1280 / 1920 | 6·6 | 175×234 | 0.748 |

**Observed CLS** over a scripted full scroll: `6.98e-6` with covers vs `4.19e-6` without — **both 0.000**, and the residual in *both* is the pre-existing animated scanner.

## Aspect-ratio policy — stated, because this is how the grid goes ragged

IGDB serves covers at 264×374 (0.706); the ratified box is 3/4 (0.750). **One uniform 3/4 box, centred crop taken at fetch time.** Not a letterbox — that puts twelve studios' pillar colours into a six-colour palette. Not per-tile ratios — that *is* the raggedness. The crop takes ~3% off top and bottom, which box art tolerates.

Files are written at **360×480**, sized to the widest tile any breakpoint actually renders (**175 CSS px, measured**) on a DPR 2 display — not to IGDB's source dimensions, which would have been ~2.2× the pixels for something no display can resolve.

## Layout untouched — with one accessibility move, recorded not smuggled

Composition, spacing, columns, gaps and the tag distribution (6 STEAM · 2 GOG · 1 EA · 2 PS · 1 PHYSICAL at position 9) are unchanged, and the treatment × hue sequence is retained verbatim as the fallback renderer.

**The one change:** ratified §7.5 put `role="img"` on the grid with `aria-hidden` children — correct for twelve decorative gradients, but it would hide twelve *real* covers from assistive technology, and the founder's brief requires distinct per-cover alt text. So with covers the grid is a `<ul>` of twelve labelled images. **The role is not moved onto the `<ul>`** — ARIA-in-HTML disallows it there, and doing so would have re-broken the `aria-allowed-role` fix recorded in `REDACTIONS.md` §3.5. *(I caught that in my own first draft; it is now asserted against.)* Amendment recorded in `blueprint.md` §7.5.

## Out of scope, verified untouched

**Terminal-mockup captions** — there is still no runnable TUI, so they stay true, and an invariant now asserts every mockup caption keeps its disclosure. **Illustrative price numbers** — untouched. "Reddit" appears nowhere; no affiliate, no premium, donation only.

## Tests

**27/27 page invariants hold in both states** (19 added), covering: explicit dimensions on every cover, lazy-loading, same-origin sources, distinct non-empty alt text, no list element carrying `role="img"`, caption/footer agreeing with what shipped, mockup captions keeping their disclosure, and the copy file matching the page verbatim.

```
cd site && npm ci && npm run build
node scripts/check-page.mjs site/dist/index.html   # 27/27
node scripts/fetch-covers.mjs --check              # what the build contains
```

## CI

Both workflows trigger on `pull_request: branches: [main]`; this PR bases on `release/0.0.2`, so **zero CI here is by design** (CI gate: main-only) — the expected green-proxy, not a gap. The build and all 27 invariants were run locally and are reproducible above.

## Still owed

1. **Credentials → real covers.** One command, data-only commit on this branch.
2. **Lighthouse + axe against the live URL** after deploy — `zerado.app` serves the pre-change page until this merges.
3. **Send the IGDB email.** Drafted; needs to go from a founder-controlled address.
